### PR TITLE
Minexpo home page & setup test leaders/leaders-block

### DIFF
--- a/packages/common/components/leaders/home-page.marko
+++ b/packages/common/components/leaders/home-page.marko
@@ -1,9 +1,12 @@
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
 $ const { site } = out.global;
+$ const expanded = defaultValue(input.expanded, false);
 
 <marko-web-leaders props={
   sectionAlias: site.get("leaders.alias"),
   open: null,
-  expanded: false,
+  expanded,
   headerImgSrc: site.get("leaders.header.imgSrc"),
   headerImgAlt: site.get("leaders.title"),
   columns: 1,

--- a/packages/common/components/leaders/marko.json
+++ b/packages/common/components/leaders/marko.json
@@ -7,7 +7,8 @@
       "template": "./all.marko"
     },
     "common-leaders-home-page": {
-      "template": "./home-page.marko"
+      "template": "./home-page.marko",
+      "@expanded": "boolean"
     },
     "common-leaders-contextual": {
       "template": "./contextual.marko",

--- a/packages/minexpo/components/blocks/directory-categories.marko
+++ b/packages/minexpo/components/blocks/directory-categories.marko
@@ -1,0 +1,17 @@
+import { getAsArray } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+import categorySectionsFragment from "../../graphql/fragments/category-sections"
+
+$ const activeId = defaultValue(input.activeId, null);
+$ const aliases = defaultValue(input.aliases, []);
+$ const contentType = defaultValue(input.contentType, "");
+$ const primaryAlias = defaultValue(input.primaryAlias, "directory");
+$ const title = defaultValue(input.title, "Categories");
+
+<marko-web-query|{ node }|
+  name="website-section"
+  params={ alias: primaryAlias, queryFragment: categorySectionsFragment }
+>
+  $ const children = getAsArray(node, "children.edges").map(({ node }) => node);
+  <directory-facets title=title facets=children active-id=activeId aliases=aliases content-type=contentType />
+</marko-web-query>

--- a/packages/minexpo/components/blocks/marko.json
+++ b/packages/minexpo/components/blocks/marko.json
@@ -7,5 +7,13 @@
       "type": "boolean",
       "default-value": true
     }
+  },
+  "<shared-directory-categories-block>": {
+    "template": "./directory-categories.marko",
+    "@aliases": "array",
+    "@active-id": "number",
+    "@content-type": "string",
+    "@primary-alias": "string",
+    "@title": "string"
   }
 }

--- a/packages/minexpo/components/page-wrappers/content/leader.marko
+++ b/packages/minexpo/components/page-wrappers/content/leader.marko
@@ -91,49 +91,33 @@ $ const { id, type, content } = input;
       </marko-web-node-list>
     </marko-web-query>
 
-  </div>
-  <div class="col-lg-4 mb-3 mb-lg-0">
-    <marko-web-node-list collapsible=false class="mt-block">
-      <@header>Request More Information</@header>
-      <@body>
-        <shared-inquiry-block content=content with-header=false modifiers=["block"] />
-      </@body>
-    </marko-web-node-list>
-
-    $ const contacts = getAsArray(content, "contacts.edges").map(({ node }) => node);
-    <marko-web-node-list class="mt-block">
-      <@header>
-        Key Contact<if(contacts.length > 1)>s</if>
-      </@header>
-      <@nodes|{ nodes }| nodes=contacts>
-        <for|node| of=nodes>
-          <common-author-card-node node=node with-email=true />
-        </for>
-      </@nodes>
-    </marko-web-node-list>
-
-    $ const videos = getAsArray(content, "videos.edges").map(({ node }) => node);
-    <marko-web-node-list class="mt-block">
-      <@header>
-        Featured Videos
-      </@header>
-      <@nodes|{ nodes }| nodes=videos>
-        <for|node| of=nodes>
-          <div class="node-list__node">
-            <common-youtube-card-node node=node link-attrs={
-              'data-company-id': content.id,
-              'data-company-name': content.name,
-            } />
+    $ const allVideos = getAsArray(content, "videos.edges").map(({ node }) => node);
+    <if(allVideos.length !== 0)>
+      $ const videos = allVideos.slice(0, 3);
+      <marko-web-node-list class="mt-block">
+        <@header>
+          Featured Videos
+        </@header>
+        <@nodes|{ nodes }| nodes=videos>
+          <div class=`card-deck-flow card-deck-flow--${videos.length}-cols`>
+            <for|node| of=nodes>
+              <div class="card-deck-flow__node">
+                <common-youtube-card-node node=node link-attrs={
+                  'data-company-id': content.id,
+                  'data-company-name': content.name,
+                } />
+              </div>
+            </for>
           </div>
-        </for>
-      </@nodes>
-      <@footer>
-        $ const url = get(content, "youtube.url");
-        <a href=url target="_blank" rel="noopener" class="btn btn-sm btn-block btn-secondary">
-          View all videos &gt;
-        </a>
-      </@footer>
-    </marko-web-node-list>
+        </@nodes>
+        <@footer>
+          $ const url = get(content, "youtube.url");
+          <a href=url target="_blank" rel="noopener" class="btn btn-sm btn-block btn-secondary">
+            View all videos &gt;
+          </a>
+        </@footer>
+      </marko-web-node-list>
+    </if>
 
     <marko-web-query|{ nodes }|
       name="all-company-content"
@@ -156,5 +140,28 @@ $ const { id, type, content } = input;
         </@header>
       </shared-content-list-flow>
     </marko-web-query>
+
+  </div>
+  <div class="col-lg-4 page-rail mb-3 mb-lg-0">
+    <marko-web-node-list collapsible=false class="mt-block">
+      <@header>Request More Information</@header>
+      <@body>
+        <shared-inquiry-block content=content with-header=false modifiers=["block"] />
+      </@body>
+    </marko-web-node-list>
+
+    $ const contacts = getAsArray(content, "contacts.edges").map(({ node }) => node);
+    <marko-web-node-list class="mt-block">
+      <@header>
+        Key Contact<if(contacts.length > 1)>s</if>
+      </@header>
+      <@nodes|{ nodes }| nodes=contacts>
+        <for|node| of=nodes>
+          <common-author-card-node node=node with-email=true />
+        </for>
+      </@nodes>
+    </marko-web-node-list>
+
+    
   </div>
 </div>

--- a/packages/minexpo/components/page-wrappers/content/leader.marko
+++ b/packages/minexpo/components/page-wrappers/content/leader.marko
@@ -48,8 +48,7 @@ $ const { id, type, content } = input;
 
     <marko-web-node-list collapsible=false class="mt-block">
       <@header>
-        <if(content.isLeader)>${site.get("leaders.title")}</if>
-        <else>Company Details</else>
+        Company Details
       </@header>
       <@body>
         <label class="content-section-header content-section-header--border">At-a-glance</label>

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -81,13 +81,7 @@ $ const includeContentTypes = (req.query.type) ? req.query.type : null;
                   </for>
                 </div>                  
               </div>
-              <marko-web-query|{ node }|
-                name="website-section"
-                params={ alias: 'directory', queryFragment: categorySectionsFragment }
-              >
-                $ const children = getAsArray(node, "children.edges").map(({ node }) => node);
-                <directory-facets title="Categories" facets=children active-id=id aliases=aliases content-type=contentType />
-              </marko-web-query>
+              <shared-directory-categories-block aliases=aliases active-id=id content-type=contentType />
 
             </div>
             <div class="col-lg-8 mb-block">

--- a/sites/minexpo.com/config/site.js
+++ b/sites/minexpo.com/config/site.js
@@ -27,7 +27,7 @@ module.exports = {
     // { provider: 'linkedin', href: 'https://www.linkedin.com/showcase/packaging-world' },
   ],
   gtm: {
-    containerId: process.env.GTM_CONTAINER_ID || 'NOT_SET',
+    containerId: process.env.GTM_CONTAINER_ID || 'GTM-5MBFGGJ',
     slotPrefix: 'pw',
   },
   wufoo: {

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -54,7 +54,7 @@ $ const { id, alias, name, pageNode } = data;
       </div>
 
       <div class="col-lg-8 mb-block">
-        <common-leaders-home-page />
+        <common-leaders-home-page expanded=true />
       </div>
       <div class="col-lg-4 mb-block page-rail">
         <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-leaders-vote-btn" />

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -32,69 +32,156 @@ $ const { id, alias, name, pageNode } = data;
     >
       <website-content-hero-flow nodes=nodes />
     </marko-web-query>
-    <marko-web-query|{ nodes }|
-      name="all-published-content"
-      params={ limit: 6, skip: 5, requiresImage: true, queryFragment }
-    >
-      <default-theme-card-deck-flow cols=3 nodes=nodes>
-        <@slot|{ node, index }|>
-          <website-content-card-node
-            image-width=340
-            node=node
-          />
-        </@slot>
-      </default-theme-card-deck-flow>
-    </marko-web-query>
-    <!-- <marko-web-page-wrapper>
-      <@section>
-        <div class="row">
-          <div class="col">
-            <div class="leaders-index-page__header-wrapper">
-              <div class="leaders-index-page__logo">
-                <marko-web-img
-                  src=site.get("leaders.header.imgSrc")
-                  alt=site.get("leaders.title")
-                />
-              </div>
-              <div class="leaders-index-page__header">
-                <h1 class="leaders-index-page__title">
-                  ${site.get("leaders.title")}
-                </h1>
-                <div class="leaders-index-page__description">
-                  <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
-                </div>
-              </div>
-              <div class="leaders-index-page__body">
-                <p>Description</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <common-leaders-all />
-      </@section>
-    </marko-web-page-wrapper> -->
-    <marko-web-query|{ nodes }|
-      name="all-published-content"
-      params={ limit: 12, skip: 11, requiresImage: true, queryFragment }
-    >
-      <website-content-card-deck-flow nodes=nodes >
-      </website-content-card-deck-flow>
-    </marko-web-query>
+
+    <div class="row">
+      <div class="col-lg-8">
+        <marko-web-query|{ nodes }|
+          name="all-published-content"
+          params={ limit: 4, skip: 5, requiresImage: true, queryFragment }
+        >
+          <default-theme-card-deck-flow cols=2 nodes=nodes>
+            <@slot|{ node, index }|>
+              <website-content-card-node
+                image-width=340
+                node=node
+              />
+            </@slot>
+          </default-theme-card-deck-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block page-rail">
+        <shared-directory-categories-block aliases=[] />
+      </div>
+
+      <div class="col-lg-8 mb-block">
+        <common-leaders-home-page />
+      </div>
+      <div class="col-lg-4 mb-block page-rail">
+        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-leaders-vote-btn" />
+        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-02-right" />
+        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-03-right" />
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/auxiliary-equipment-and-supplies", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/auxiliary-equipment-and-supplies">Auxiliary</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/components-and-replacement-equipment", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/components-and-replacement-equipment">Components</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/electrical-equipment-and-supplies", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/electrical-equipment-and-supplies">Electrical</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/engineering-construction-consulting-and-mining-related-services", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/engineering-construction-consulting-and-mining-related-services">Engineering, Construction</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/material-handling-equipment", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/material-handling-equipment">Material Handling</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/mining-equipment", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/mining-equipment">Mining</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/other-related-equipment-products-and-services", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/other-related-equipment-products-and-services">Other</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/power-and-power-transmission-equipment", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/power-and-power-transmission-equipment">Power & Power Transmission </marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "directory/processingpreparation-equipment", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/directory/processingpreparation-equipment">Processing/Preparation </marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+    </div>
+
     <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-bottom-wide" />
 
   </@page>
-  <!-- <@below-page>
-    <marko-web-resolve-page|{ data: section }| node=pageNode>
-      $ const aliases = hierarchyAliases(section);
-      <marko-web-load-more
-        component-name="content-load-more-flow"
-        component-input={ aliases }
-        fragment-name="content-list"
-        query-name="all-published-content"
-        query-params={ limit: 12, skip: 23, requiresImage: true }
-        max-pages=0
-        page-input={ for: "website-section", id }
-      />
-    </marko-web-resolve-page>
-  </@below-page> -->
+  
 </marko-web-website-section-page-layout>


### PR DESCRIPTION
- Make new directory-categories block
- Update directory page to use new category block
- Update home page to have categories, leaders & section blocks
- Add ability to set the block with expanded as true

![mine-home](https://user-images.githubusercontent.com/3845869/103798349-2dea6680-500f-11eb-958c-3e2dc96dfa81.png)
![mine-leaders-page](https://user-images.githubusercontent.com/3845869/103798363-32af1a80-500f-11eb-8a1c-d39bca8a8e75.png)
