### PR TITLE
Adjust header, leaders, homepage & directory page layout

### DIFF
--- a/packages/common/components/leaders/home-page.marko
+++ b/packages/common/components/leaders/home-page.marko
@@ -12,6 +12,7 @@ $ const expanded = defaultValue(input.expanded, false);
   columns: 1,
   offsetTop: 50,
   viewAllHref: '/leaders',
+  calloutValue: site.get('leaders.title'),
   mediaQueries: [
     { prop: "open", value: "right", query: "(min-width: 1490px)" },
     { prop: "columns", value: 2, query: "(min-width: 700px)" },

--- a/packages/directory/components/facet-container/facet-container.marko
+++ b/packages/directory/components/facet-container/facet-container.marko
@@ -1,9 +1,14 @@
-$ const { facets, title, aliases } = input;
+$ const { facets, title, description, aliases } = input;
 
 <if(facets.length)>
   <div class="directory-facets">
     <if(title)>
       <h3 class="directory-facets__title">${title}</h3>
+    </if>
+    <if(description)>
+      <div class="directory-facets__description">
+        $!{description}
+      </div>
     </if>
     <facet-list
       facets=facets

--- a/packages/directory/components/facet-container/marko-tag.json
+++ b/packages/directory/components/facet-container/marko-tag.json
@@ -4,6 +4,7 @@
     "required": true
   },
   "@title": "string",
+  "@description": "string",
   "@content-type": "string",
   "@active-id": {
     "type": "string",

--- a/packages/directory/components/facets.marko
+++ b/packages/directory/components/facets.marko
@@ -19,5 +19,6 @@ $ const aliases = getAsArray(input, "aliases");
   aliases=aliases
   content-type=input.contentType
   title=input.title
+  description=input.description
   active-id=input.activeId
 />

--- a/packages/directory/components/marko.json
+++ b/packages/directory/components/marko.json
@@ -5,6 +5,7 @@
     "@content-type": "string",
     "@aliases": "array",
     "@active-id": "expression",
-    "@title": "string"
+    "@title": "string",
+    "@description": "string"
   }
 }

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@base-cms/marko-core": "^1.38.0",
     "@base-cms/marko-web": "^1.37.0",
+    "@base-cms/marko-web-gam": "^1.37.0",
     "@base-cms/marko-web-theme-default": "^1.41.1",
     "@base-cms/object-path": "^1.37.0"
   }

--- a/packages/minexpo/components/blocks/directory-categories.marko
+++ b/packages/minexpo/components/blocks/directory-categories.marko
@@ -7,11 +7,12 @@ $ const aliases = defaultValue(input.aliases, []);
 $ const contentType = defaultValue(input.contentType, "");
 $ const primaryAlias = defaultValue(input.primaryAlias, "directory");
 $ const title = defaultValue(input.title, "Categories");
+$ const description = defaultValue(input.description, "");
 
 <marko-web-query|{ node }|
   name="website-section"
   params={ alias: primaryAlias, queryFragment: categorySectionsFragment }
 >
   $ const children = getAsArray(node, "children.edges").map(({ node }) => node);
-  <directory-facets title=title facets=children active-id=activeId aliases=aliases content-type=contentType />
+  <directory-facets title=title description=description facets=children active-id=activeId aliases=aliases content-type=contentType />
 </marko-web-query>

--- a/packages/minexpo/components/blocks/marko.json
+++ b/packages/minexpo/components/blocks/marko.json
@@ -14,6 +14,7 @@
     "@active-id": "number",
     "@content-type": "string",
     "@primary-alias": "string",
-    "@title": "string"
+    "@title": "string",
+    "@description": "string"
   }
 }

--- a/packages/minexpo/package.json
+++ b/packages/minexpo/package.json
@@ -14,6 +14,7 @@
     "@ascend-media/package-directory": "^0.3.13",
     "@base-cms/marko-core": "^1.38.0",
     "@base-cms/marko-web": "^1.37.0",
+    "@base-cms/marko-web-gam": "^1.37.0",
     "@base-cms/marko-web-gtm": "^1.37.0",
     "@base-cms/marko-web-inquiry": "^1.38.0",
     "@base-cms/marko-web-native-x": "^1.37.0",

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -9,8 +9,8 @@ $ const { apollo, GAM, pagination: p, req } = out.global;
 $ const contentType = defaultValue(req.query.type, 'Company');
 $ const supportedContendTypes = { 
   Company: 'Exhibitor',
-  PressRelease: 'Press Release',
   Product: 'Product',
+  PressRelease: 'Press Release',
   News: 'News' 
 };
 
@@ -59,38 +59,41 @@ $ const perPage = 20;
         <@section>
           $ const aliases = hierarchyAliases(section);
           <div class="row">
-            <div class="col-lg-4 mb-block">
-              <div class="content-type-facets">
-                <h3 class="content-type-facets__title">Content Types</h3>
-                <div class="content-type-facets__list">
-                  <for|key,value| in=supportedContendTypes>
-                    <if(key === 'Company')>
-                    $ const activeModifier = ('Company' === contentType) ? '--active' : '';
-                    <div class=`content-type-facets__item content-type-facets__item--${key}`>
-                      <a class=`content-type-facets__link content-type-facets__link${activeModifier}` href=`/${section.alias}`>
-                        ${value}
-                      </a>
-                    </div>
-                    </if>
-                    <else-if(key == contentType)>
-                      <div class=`content-type-facets__item content-type-facets__item--${key}`>
-                        <a class=`content-type-facets__link content-type-facets__link--active` href=`/${section.alias}`>
-                          ${value}
-                        </a>
-                      </div>
-                    </else-if>
-                    <else>
-                      <div class=`content-type-facets__item content-type-facets__item--${key}`>
-                        <a class=`content-type-facets__link content-type-facets__link` href=`/${section.alias}?type=${key}`>
-                          ${value}
-                        </a>
-                      </div>
-                    </else>
-                  </for>
-                </div>                  
+            <div class="col-lg-4">
+              <div class="mb-block">
+                <shared-directory-categories-block aliases=aliases active-id=id content-type=contentType />
               </div>
-              <shared-directory-categories-block aliases=aliases active-id=id content-type=contentType />
-
+              <div class="mb-block">
+                <div class="content-type-facets">
+                  <h3 class="content-type-facets__title">Content Types</h3>
+                  <div class="content-type-facets__list">
+                    <for|key,value| in=supportedContendTypes>
+                      <if(key === 'Company')>
+                      $ const activeModifier = ('Company' === contentType) ? '--active' : '';
+                      <div class=`content-type-facets__item content-type-facets__item--${key}`>
+                        <a class=`content-type-facets__link content-type-facets__link${activeModifier}` href=`/${section.alias}`>
+                          ${value}
+                        </a>
+                      </div>
+                      </if>
+                      <else-if(key == contentType)>
+                        <div class=`content-type-facets__item content-type-facets__item--${key}`>
+                          <a class=`content-type-facets__link content-type-facets__link--active` href=`/${section.alias}`>
+                            ${value}
+                          </a>
+                        </div>
+                      </else-if>
+                      <else>
+                        <div class=`content-type-facets__item content-type-facets__item--${key}`>
+                          <a class=`content-type-facets__link content-type-facets__link` href=`/${section.alias}?type=${key}`>
+                            ${value}
+                          </a>
+                        </div>
+                      </else>
+                    </for>
+                  </div>                  
+                </div>
+              </div>
             </div>
             <div class="col-lg-8 mb-block">
               <div class="row">

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -68,7 +68,9 @@ $ const perPage = 20;
           $ const aliases = hierarchyAliases(section);
           <div class="row">
             <div class="col-lg-4">
-              <marko-web-gam-display-ad id="gpt-ad-rail1" />
+              <div class="mb-block">
+                <marko-web-gam-display-ad id="gpt-ad-rail1" />
+              </div>
               <div class="mb-block">
                 <shared-directory-categories-block aliases=aliases active-id=id content-type=contentType />
               </div>

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -6,9 +6,9 @@ import { retrieveSections } from "../../utils/retrieve-sections";
 import categorySectionsFragment from "../../graphql/fragments/category-sections"
 
 $ const { apollo, GAM, pagination: p, req } = out.global;
-$ const contentType = defaultValue(req.query.type, null);
+$ const contentType = defaultValue(req.query.type, 'Company');
 $ const supportedContendTypes = { 
-  Company: 'Company',
+  Company: 'Exhibitor',
   PressRelease: 'Press Release',
   Product: 'Product',
   News: 'News' 
@@ -21,15 +21,15 @@ $ const {
   pageNode,
 } = input;
 $ const perPage = 20;
-$ const includeContentTypes = (req.query.type) ? req.query.type : null;
 
 <marko-web-resolve-page|{ data: section }| node=pageNode>
   $ let queryParams = {
     sectionId: section.id,
     optionName: ["Standard"],
     queryFragment,
+    includeContentTypes: [contentType]
   };
-  $ if (includeContentTypes) queryParams.includeContentTypes = [includeContentTypes];
+  $ if ('Company' === contentType) queryParams.sort = { field: 'name', order: 'asc' };
   <marko-web-website-section-page-layout id=id alias=alias name=name>
     <@head>
       <marko-web-gtm-website-section-context|{ context }| alias=alias>
@@ -64,13 +64,21 @@ $ const includeContentTypes = (req.query.type) ? req.query.type : null;
                 <h3 class="content-type-facets__title">Content Types</h3>
                 <div class="content-type-facets__list">
                   <for|key,value| in=supportedContendTypes>
-                    <if(key == contentType)>
+                    <if(key === 'Company')>
+                    $ const activeModifier = ('Company' === contentType) ? '--active' : '';
+                    <div class=`content-type-facets__item content-type-facets__item--${key}`>
+                      <a class=`content-type-facets__link content-type-facets__link${activeModifier}` href=`/${section.alias}`>
+                        ${value}
+                      </a>
+                    </div>
+                    </if>
+                    <else-if(key == contentType)>
                       <div class=`content-type-facets__item content-type-facets__item--${key}`>
                         <a class=`content-type-facets__link content-type-facets__link--active` href=`/${section.alias}`>
                           ${value}
                         </a>
                       </div>
-                    </if>
+                    </else-if>
                     <else>
                       <div class=`content-type-facets__item content-type-facets__item--${key}`>
                         <a class=`content-type-facets__link content-type-facets__link` href=`/${section.alias}?type=${key}`>
@@ -100,8 +108,14 @@ $ const includeContentTypes = (req.query.type) ? req.query.type : null;
                       modifiers=['content-list']
                     >
                       <@header>
-                        <if(p.page > 1)>${section.name}: Page ${p.page}</if>
-                        <else>Latest in ${section.name}</else>
+                        <if('Company' === contentType)>
+                          <if(p.page > 1)>${supportedContendTypes[contentType]} in ${section.name}: Page ${p.page}</if>
+                          <else>${supportedContendTypes[contentType]} in ${section.name}</else>
+                        </if>
+                        <else>
+                          <if(p.page > 1)>${section.name}: Page ${p.page}</if>
+                          <else>Latest ${supportedContendTypes[contentType]} in ${section.name}</else>
+                        </else>
                       </@header>
                       <@nodes nodes=nodes>
                         <@slot|{ node }|>

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -7,11 +7,11 @@ import categorySectionsFragment from "../../graphql/fragments/category-sections"
 
 $ const { apollo, GAM, pagination: p, req } = out.global;
 $ const contentType = defaultValue(req.query.type, 'Company');
-$ const supportedContendTypes = { 
+$ const supportedContendTypes = {
   Company: 'Exhibitor',
   Product: 'Product',
   PressRelease: 'Press Release',
-  News: 'News' 
+  News: 'News'
 };
 
 $ const {
@@ -35,6 +35,12 @@ $ const perPage = 20;
       <marko-web-gtm-website-section-context|{ context }| alias=alias>
         <marko-web-gtm-push data=context />
       </marko-web-gtm-website-section-context>
+      $ const aliases = hierarchyAliases(section);
+      $ const adSlots = {
+        "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
+      };
+      <marko-web-gam-slots slots=adSlots />
       <query-total-count|data| name="website-scheduled-content" params=queryParams>
         <pagination-controls
           per-page=perPage
@@ -44,7 +50,9 @@ $ const perPage = 20;
         />
       </query-total-count>
     </@head>
-
+    <@above-container>
+      <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["above-container"] />
+    </@above-container>
     <@page>
       <marko-web-page-wrapper class="mb-block">
         <@section>
@@ -60,6 +68,7 @@ $ const perPage = 20;
           $ const aliases = hierarchyAliases(section);
           <div class="row">
             <div class="col-lg-4">
+              <marko-web-gam-display-ad id="gpt-ad-rail1" />
               <div class="mb-block">
                 <shared-directory-categories-block aliases=aliases active-id=id content-type=contentType />
               </div>
@@ -91,7 +100,7 @@ $ const perPage = 20;
                         </div>
                       </else>
                     </for>
-                  </div>                  
+                  </div>
                 </div>
               </div>
             </div>

--- a/sites/minexpo.com/config/gam.js
+++ b/sites/minexpo.com/config/gam.js
@@ -1,6 +1,6 @@
 const GAMConfiguration = require('@base-cms/marko-web-gam/config');
 
-const config = new GAMConfiguration('6407152');
+const config = new GAMConfiguration('6407152', { basePath: 'minexpo' });
 
 config
   .setTemplate('leaderboard', {
@@ -14,12 +14,9 @@ config
 
 config
   .setAliasAdUnits('default', [
-    { name: 'leaderboard', templateName: 'leaderboard', path: 'pw_leaderboard' },
-    { name: 'article-top-below-head', templateName: 'leaderboard', path: 'pw-article-top-below-head' },
-    { name: 'home-top-below-head', templateName: 'leaderboard', path: 'pw-home-top-below-head' },
-    { name: 'imu1', size: [300, 250], path: 'pw_imu_1' },
-    { name: 'imu2', size: [300, 250], path: 'pw_imu_3' },
-    { name: 'skyscraper', options: { size: [300, 600] }, path: 'pw_skyscraper' },
+    { name: 'lb1', templateName: 'leaderboard', path: 'lb1' },
+    { name: 'rail1', options: { size: [300, 250] }, path: 'rail1' },
+    { name: 'rail2', options: { size: [300, 600] }, path: 'rail1' },
   ]);
 
 module.exports = config;

--- a/sites/minexpo.com/config/gam.js
+++ b/sites/minexpo.com/config/gam.js
@@ -16,7 +16,7 @@ config
   .setAliasAdUnits('default', [
     { name: 'lb1', templateName: 'leaderboard', path: 'lb1' },
     { name: 'rail1', options: { size: [300, 250] }, path: 'rail1' },
-    { name: 'rail2', options: { size: [300, 600] }, path: 'rail1' },
+    { name: 'rail2', options: { size: [300, 600] }, path: 'rail2' },
   ]);
 
 module.exports = config;

--- a/sites/minexpo.com/config/leaders.js
+++ b/sites/minexpo.com/config/leaders.js
@@ -1,7 +1,7 @@
 module.exports = {
-  title: 'Leaders in Mining',
+  title: 'Featured Exhibitors',
   alias: 'leaders',
   header: {
-    imgSrc: 'https://img.packworld.com/files/base/pmmi/all/leaders/pw-2020.png?h=90',
+    imgSrc: 'https://img.packworld.com/files/base/ascend/minex/image/static/leaders-logo.png?h=90',
   },
 };

--- a/sites/minexpo.com/config/navigation.js
+++ b/sites/minexpo.com/config/navigation.js
@@ -1,11 +1,18 @@
-const topics = [
-  { href: '/directory/auxiliary-equipment-and-supplies', label: 'Auxiliary' },
-  { href: '/directory/components-and-replacement-equipment', label: 'Components' },
-  { href: '/directory/electrical-equipment-and-supplies', label: 'Electrical' },
-  { href: 'material-handling-equipment', label: 'Material Handling' },
-  { href: '/directory/power-and-power-transmission-equipment', label: 'Power' },
-  { href: '/directory/processingpreparation-equipment', label: 'Processing/Preparation' },
-  { href: '/directory', label: 'More...' },
+// const topics = [
+//   { href: '/directory/auxiliary-equipment-and-supplies', label: 'Auxiliary' },
+//   { href: '/directory/components-and-replacement-equipment', label: 'Components' },
+//   { href: '/directory/electrical-equipment-and-supplies', label: 'Electrical' },
+//   { href: 'material-handling-equipment', label: 'Material Handling' },
+//   { href: '/directory/power-and-power-transmission-equipment', label: 'Power' },
+//   { href: '/directory/processingpreparation-equipment', label: 'Processing/Preparation' },
+//   { href: '/directory', label: 'More...' },
+// ];
+const primary = [
+  { href: '/directory', label: 'Directory' },
+  { href: '/directory?type="News', label: 'News' },
+  { href: 'javascript:void(0)', label: 'Maps' },
+  { href: 'javascript:void(0)', label: 'Export Directory' },
+  { href: 'https://www.MINExpo.com', label: 'MINExpo.com' },
 ];
 
 const resources = [
@@ -16,7 +23,7 @@ const resources = [
 
 module.exports = {
   primary: {
-    items: [...topics],
+    items: [...primary],
   },
   secondary: {
     items: [...resources],
@@ -32,6 +39,10 @@ module.exports = {
   menu: [
     {
       label: 'Topics',
+      items: [...primary],
+    },
+    {
+      label: 'Exhibitors By Category',
       items: [
         { href: '/directory/auxiliary-equipment-and-supplies', label: 'Auxiliary Equipment and Supplies' },
         { href: '/directory/components-and-replacement-equipment', label: 'Components & Replacement Equipment' },

--- a/sites/minexpo.com/config/site.js
+++ b/sites/minexpo.com/config/site.js
@@ -1,8 +1,10 @@
+const gam = require('./gam');
 const navigation = require('./navigation');
 const leaders = require('./leaders');
 const nativeX = require('./native-x');
 
 module.exports = {
+  gam,
   leaders,
   navigation,
   nativeX,

--- a/sites/minexpo.com/config/site.js
+++ b/sites/minexpo.com/config/site.js
@@ -11,9 +11,9 @@ module.exports = {
   company: 'MINExpo Show Directory',
   logos: {
     navbar: {
-      src: 'https://p1-cms-assets-ascend.imgix.net/files/base/ascend/minexpo/image/static/minexpo-logo.png?h=45',
+      src: 'https://p1-cms-assets-ascend.imgix.net/files/base/ascend/minexpo/image/static/minexpo-logo.png?h=90',
       srcset: [
-        'https://p1-cms-assets-ascend.imgix.net/files/base/ascend/minexpo/image/static/minexpo-logo.png?h=90 2x',
+        'https://p1-cms-assets-ascend.imgix.net/files/base/ascend/minexpo/image/static/minexpo-logo.png?h=`180 2x',
       ],
     },
     footer: {

--- a/sites/minexpo.com/index.js
+++ b/sites/minexpo.com/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
+const { set, getAsObject } = require('@base-cms/object-path');
 const paginated = require('@ascend-media/package-minexpo/middleware/paginated');
 const { version } = require('./package.json');
 const routes = require('./server/routes');
@@ -23,6 +24,11 @@ module.exports = startServer({
   version,
   onStart: (app) => {
     app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+
+    // Setup GAM.
+    const gamConfig = getAsObject(siteConfig, 'gam');
+    if (gamConfig) set(app.locals, 'GAM', gamConfig);
+
     app.use(paginated());
   },
   onAsyncBlockError: e => newrelic.noticeError(e),

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -3,18 +3,18 @@
 $theme-font-family-sans-serif: "Lato", sans-serif;
 $theme-font-family-serif: "Source Serif Pro", serif;
 
-$primary: #3155fc;
+$primary: #51659e; //#3155fc;
 $secondary: #495057;
 $light: #e9ecef;
 $dark: #212529;
 $info: #6c757d;
 $dark-bg-color: #00337b;
-$light-bg-color: #0a6fff;
+$light-bg-color: #51659e;
 $background: $dark-bg-color;
 $link-color: $light-bg-color;
 
-// $theme-site-navbar-secondary-bg-color: $light-bg-color;
-$theme-site-navbar-primary-bg-color: $dark-bg-color;
+$theme-site-navbar-secondary-bg-color: $dark-bg-color;
+$theme-site-navbar-primary-bg-color: $light-bg-color;
 $theme-site-navbar-primary-font-size: 14px;
 
 $theme-site-navbar-secondary-font-size: 12px;
@@ -25,9 +25,11 @@ $theme-site-footer-secondary-bg-color: $dark-bg-color;
 $theme-load-more-button-background-color: $dark-bg-color;
 $theme-load-more-button-border-color: $dark-bg-color;
 
-$leaders-primary-color: #002f7b;
-$leaders-primary-color-light: #005bac;
-$leaders-accent-color: #d557af;
+$leaders-primary-color: #51659e;
+$leaders-primary-color-light: $light-bg-color;
+$leaders-accent-color: $dark-bg-color;
+
+$leaders-header-bg-color: #51659e;
 
 $theme-site-header-breakpoints: (
   hide-secondary: 790px,
@@ -60,3 +62,20 @@ $theme-site-header-breakpoints: (
   }
 }
 
+.directory-facets {
+  &__description {
+    padding: 10px;
+    margin: 10px 0;
+    border-bottom: solid $gray-100;
+  }
+}
+
+.leaders-section{
+  &--with-parent{
+    .leaders-section{
+      &__title {
+        display: none;
+      }
+    }
+  }
+}

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -15,6 +15,7 @@ $link-color: $light-bg-color;
 
 $theme-site-navbar-secondary-bg-color: #fff;
 $theme-site-navbar-primary-bg-color: $light-bg-color;
+$theme-site-navbar-primary-link-color: #fff;
 $theme-site-navbar-primary-font-size: 14px;
 
 $theme-site-navbar-secondary-font-size: 12px;
@@ -41,6 +42,12 @@ $theme-site-header-breakpoints: (
 
 @import "../../node_modules/@ascend-media/package-common/scss/common";
 @import "../../node_modules/@ascend-media/package-minexpo/scss/index";
+
+.site-navbar {
+  &__logo {
+    height: 60px;
+  }
+}
 
 .load-more-trigger > button:hover {
   background-color: $light-bg-color;

--- a/sites/minexpo.com/server/templates/content/contact.marko
+++ b/sites/minexpo.com/server/templates/content/contact.marko
@@ -14,17 +14,15 @@ $ const { id, type, pageNode } = data;
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
-        "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
-        "gpt-ad-imu1": GAM.getAdUnit({ name: "imu1", aliases, size: [300, 250]}),
-        "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
+        "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
       };
       <marko-web-gam-slots slots=adSlots />
       <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
-    <marko-web-gam-display-ad id="gpt-ad-leaderboard" modifiers=["above-container"] />
-    <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-top-below-head" modifiers=["above-container"] />
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["above-container"] />
   </@above-container>
   <@page>
 
@@ -76,7 +74,7 @@ $ const { id, type, pageNode } = data;
           </marko-web-query>
         </div>
         <div class="col-lg-4 page-rail">
-          <marko-web-gam-display-ad id="gpt-ad-skyscraper" modifiers=["in-card"] />
+          <marko-web-gam-display-ad id="gpt-ad-rail1" modifiers=["in-card"] />
         </div>
       </div>
 

--- a/sites/minexpo.com/server/templates/content/document.marko
+++ b/sites/minexpo.com/server/templates/content/document.marko
@@ -17,16 +17,15 @@ $ const displayPublishedDate = false;
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
-        "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
-        "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
+        "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
       };
       <marko-web-gam-slots slots=adSlots />
       <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
-    <marko-web-gam-display-ad id="gpt-ad-leaderboard" modifiers=["above-container"] />
-    <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-top-below-head" modifiers=["above-container"] />
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["above-container"] />
   </@above-container>
   <@page>
 
@@ -87,7 +86,7 @@ $ const displayPublishedDate = false;
           </marko-web-query>
         </div>
         <div class="col-lg-4 page-rail">
-          <marko-web-gam-display-ad id="gpt-ad-skyscraper" modifiers=["in-card"] />
+          <marko-web-gam-display-ad id="gpt-ad-rail1" modifiers=["in-card"] />
         </div>
       </div>
 

--- a/sites/minexpo.com/server/templates/content/index.marko
+++ b/sites/minexpo.com/server/templates/content/index.marko
@@ -17,16 +17,15 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
-        "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
-        "gpt-ad-imu1": GAM.getAdUnit({ name: "imu1", aliases, size: [300, 250]}),
-        "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
+        "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
       };
       <marko-web-gam-slots slots=adSlots />
       <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
-    <marko-web-gam-display-ad id="gpt-ad-leaderboard" modifiers=["above-container"] />
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["above-container"] />
     <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-top-below-head" modifiers=["above-container"] />
   </@above-container>
   <@page>
@@ -103,30 +102,15 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 <common-featured-companies content-id=content.id />
               </if>
 
-              <!-- Div for BI Library -->
-              <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-bilibrary" class="mt-3" />
-
             </default-theme-page-contents>
 
             <aside class="col-lg-4 page-rail">
               <shared-inquiry-block content=content />
 
-              <marko-web-gam-display-ad id="gpt-ad-imu1" />
-
-              <!-- Div for Leaders Button -->
-              <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-leaders-vote-btn" />
+              <marko-web-gam-display-ad id="gpt-ad-rail1" />
 
               <!-- Leaders block here -->
               <common-leaders-contextual content-id=content.id />
-
-              <!-- Div for Audience -->
-              <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-01-right" />
-
-              <!-- Div for Control Systems Integrators Report -->
-              <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-02-right" />
-
-              <!-- Div for Marketing -->
-              <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-03-right" />
 
             </aside>
           </div>
@@ -155,7 +139,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
           </marko-web-query>
         </div>
         <div class="col-lg-4 page-rail">
-          <marko-web-gam-display-ad id="gpt-ad-skyscraper" modifiers=["in-card"] />
+          <!-- <marko-web-gam-display-ad id="gpt-ad-rail2" modifiers=["in-card"] /> -->
         </div>
       </div>
 
@@ -174,7 +158,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
 
       <div class="row">
         <div class="col-lg-4 page-rail">
-          <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-04-left" />
+          <!-- <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-04-left" /> -->
         </div>
         <div class="col-lg-8">
           <marko-web-query|{ nodes }|
@@ -203,13 +187,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <@native-x index=2 name="load-more" />
             </website-content-card-deck-flow>
           </marko-web-query>
-        </div>
-      </div>
-
-      <!-- Div for Audience -->
-      <div class="row">
-        <div class="col-lg-12 mb-4">
-          <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="article-bottom-wide" />
         </div>
       </div>
 

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -73,7 +73,7 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col">
         <marko-web-query|{ nodes }|
           name="all-published-content"
-          params={ limit: 8, skip: 6, requiresImage: true, queryFragment }
+          params={ limit: 12, skip: 6, requiresImage: true, queryFragment }
         >
           <default-theme-card-deck-flow cols=3 nodes=nodes>
             <@slot|{ node, index }|>
@@ -81,9 +81,6 @@ $ const { id, alias, name, pageNode } = data;
                 image-width=340
                 node=node
               />
-            </@slot>
-            <@slot position="after" index=2>
-              <marko-web-gam-display-ad id="gpt-ad-rail1" modifiers=["in-card"] />
             </@slot>
           </default-theme-card-deck-flow>
         </marko-web-query>

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -64,118 +64,19 @@ $ const { id, alias, name, pageNode } = data;
     </div>
 
     <div class="row">
-      <div class="col-lg-4 mb-block">
+      <div class="col">
         <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/auxiliary-equipment-and-supplies", limit: 4, queryFragment }
+          name="all-published-content"
+          params={ limit: 9, skip: 9, requiresImage: true, queryFragment }
         >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/auxiliary-equipment-and-supplies">Auxiliary</marko-web-link>
-            </@header>
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-      <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/components-and-replacement-equipment", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/components-and-replacement-equipment">Components</marko-web-link>
-            </@header>
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-      <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/electrical-equipment-and-supplies", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/electrical-equipment-and-supplies">Electrical</marko-web-link>
-            </@header>
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/engineering-construction-consulting-and-mining-related-services", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/engineering-construction-consulting-and-mining-related-services">Engineering, Construction</marko-web-link>
-            </@header>
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-      <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/material-handling-equipment", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/material-handling-equipment">Material Handling</marko-web-link>
-            </@header>
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-      <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/mining-equipment", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/mining-equipment">Mining</marko-web-link>
-            </@header>
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/other-related-equipment-products-and-services", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/other-related-equipment-products-and-services">Other</marko-web-link>
-            </@header>
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-      <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/power-and-power-transmission-equipment", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/power-and-power-transmission-equipment">Power & Power Transmission </marko-web-link>
-            </@header>
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-      <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "directory/processingpreparation-equipment", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/directory/processingpreparation-equipment">Processing/Preparation </marko-web-link>
-            </@header>
-          </website-content-list-flow>
+          <default-theme-card-deck-flow cols=3 nodes=nodes>
+            <@slot|{ node, index }|>
+              <website-content-card-node
+                image-width=340
+                node=node
+              />
+            </@slot>
+          </default-theme-card-deck-flow>
         </marko-web-query>
       </div>
     </div>

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -15,21 +15,15 @@ $ const { id, alias, name, pageNode } = data;
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
       $ const adSlots = {
-        "gpt-ad-leaderboard":     GAM.getAdUnit({ name: "leaderboard", aliases }),
-        "gpt-ad-home-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
+        "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
+        "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
       };
-      
-       <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
-    <!-- <marko-web-gam-display-ad id="gpt-ad-leaderboard" modifiers=["above-container"] /> -->
-    <div id="gpt-ad-lb1" class="ad-container ad-container--top-of-page">
-      <div style="border: 0pt none;">
-        <img src="https://via.placeholder.com/970x90.png?text=970x90+Leaderboard" />
-      </div>
-    </div>
-    <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-top-below-head" modifiers=["above-container"] />
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["above-container"] />
   </@above-container>
   <@page>
     <marko-web-query|{ nodes }|
@@ -45,7 +39,7 @@ $ const { id, alias, name, pageNode } = data;
           <shared-directory-categories-block aliases=[] title="Exibitor By Category" description="Select a category below to view the Exibitors within the selected category." />
         </marko-web-element>
       </marko-web-block>
-      
+
     </marko-web-query>
 
     <div class="row">
@@ -65,26 +59,13 @@ $ const { id, alias, name, pageNode } = data;
         </marko-web-query>
       </div>
       <div class="col-lg-4 mb-block page-rail">
-        <div id="gpt-ad-lb1" class="ad-container ad-container--top-of-page">
-          <div style="border: 0pt none;">
-            <img src="https://via.placeholder.com/300x250.png?text=300x250+Medium+Rectangle" />
-          </div>
-        </div>
+        <marko-web-gam-display-ad id="gpt-ad-rail1" />
       </div>
 
       <div class="col-lg-8 mb-block">
         <common-leaders-home-page expanded=true />
       </div>
-      <div class="col-lg-4 mb-block page-rail">
-        <div id="gpt-ad-lb1" class="ad-container ad-container--top-of-page">
-          <div style="border: 0pt none;">
-            <img src="https://via.placeholder.com/300x600.png?text=300x600+Half+Page" />
-          </div>
-        </div>
-        <!-- <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-leaders-vote-btn" />
-        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-02-right" />
-        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-03-right" /> -->
-      </div>
+      <marko-web-gam-display-ad id="gpt-ad-rail2" />
     </div>
 
     <div class="row">
@@ -105,8 +86,6 @@ $ const { id, alias, name, pageNode } = data;
       </div>
     </div>
 
-    <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-bottom-wide" />
-
   </@page>
-  
+
 </marko-web-website-section-page-layout>

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -18,19 +18,34 @@ $ const { id, alias, name, pageNode } = data;
         "gpt-ad-leaderboard":     GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-home-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
+      
        <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
-    <marko-web-gam-display-ad id="gpt-ad-leaderboard" modifiers=["above-container"] />
+    <!-- <marko-web-gam-display-ad id="gpt-ad-leaderboard" modifiers=["above-container"] /> -->
+    <div id="gpt-ad-lb1" class="ad-container ad-container--top-of-page">
+      <div style="border: 0pt none;">
+        <img src="https://via.placeholder.com/970x90.png?text=970x90+Leaderboard" />
+      </div>
+    </div>
     <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-top-below-head" modifiers=["above-container"] />
   </@above-container>
   <@page>
     <marko-web-query|{ nodes }|
       name="all-published-content"
-      params={ limit: 5, requiresImage: true, queryFragment }
+      params={ limit: 1, requiresImage: true, queryFragment }
     >
-      <website-content-hero-flow nodes=nodes />
+      <!-- <website-content-hero-flow nodes=nodes /> -->
+      <marko-web-block name="hero-flow">
+        <marko-web-element name="hero" block-name="hero-flow">
+          <website-content-card-node node=nodes[0] image-width=630 title-modifiers=["large"] />
+        </marko-web-element>
+        <marko-web-element name="list" block-name="hero-flow">
+          <shared-directory-categories-block aliases=[] title="Exibitor By Category" description="Select a category below to view the Exibitors within the selected category." />
+        </marko-web-element>
+      </marko-web-block>
+      
     </marko-web-query>
 
     <div class="row">
@@ -50,16 +65,25 @@ $ const { id, alias, name, pageNode } = data;
         </marko-web-query>
       </div>
       <div class="col-lg-4 mb-block page-rail">
-        <shared-directory-categories-block aliases=[] />
+        <div id="gpt-ad-lb1" class="ad-container ad-container--top-of-page">
+          <div style="border: 0pt none;">
+            <img src="https://via.placeholder.com/300x250.png?text=300x250+Medium+Rectangle" />
+          </div>
+        </div>
       </div>
 
       <div class="col-lg-8 mb-block">
         <common-leaders-home-page expanded=true />
       </div>
       <div class="col-lg-4 mb-block page-rail">
-        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-leaders-vote-btn" />
+        <div id="gpt-ad-lb1" class="ad-container ad-container--top-of-page">
+          <div style="border: 0pt none;">
+            <img src="https://via.placeholder.com/300x600.png?text=300x600+Half+Page" />
+          </div>
+        </div>
+        <!-- <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-leaders-vote-btn" />
         <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-02-right" />
-        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-03-right" />
+        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-03-right" /> -->
       </div>
     </div>
 

--- a/sites/minexpo.com/server/templates/magazine/index.marko
+++ b/sites/minexpo.com/server/templates/magazine/index.marko
@@ -13,7 +13,7 @@ $ const description = site.get("magazines.description");
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/magazine/issue.marko
+++ b/sites/minexpo.com/server/templates/magazine/issue.marko
@@ -11,7 +11,7 @@ $ const { id, pageNode } = data;
     </marko-web-gtm-magazine-issue-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/magazine/publication.marko
+++ b/sites/minexpo.com/server/templates/magazine/publication.marko
@@ -9,7 +9,7 @@ $ const { id, pageNode } = data;
     </marko-web-gtm-magazine-publication-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper>
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/published-content/documents.marko
+++ b/sites/minexpo.com/server/templates/published-content/documents.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <!-- <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] /> -->
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/published-content/podcasts.marko
+++ b/sites/minexpo.com/server/templates/published-content/podcasts.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/published-content/supplier-events.marko
+++ b/sites/minexpo.com/server/templates/published-content/supplier-events.marko
@@ -16,7 +16,7 @@ $ const now = (new Date()).valueOf();
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/published-content/videos.marko
+++ b/sites/minexpo.com/server/templates/published-content/videos.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/published-content/webinars.marko
+++ b/sites/minexpo.com/server/templates/published-content/webinars.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/published-content/white-papers.marko
+++ b/sites/minexpo.com/server/templates/published-content/white-papers.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/search.marko
+++ b/sites/minexpo.com/server/templates/search.marko
@@ -14,7 +14,7 @@ $ const description = `Search ${config.siteName()}`;
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/subscribe/index.marko
+++ b/sites/minexpo.com/server/templates/subscribe/index.marko
@@ -13,7 +13,7 @@ $ const description = `${config.siteName()} has products that deliver powerful c
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">

--- a/sites/minexpo.com/server/templates/website-section/contact-us.marko
+++ b/sites/minexpo.com/server/templates/website-section/contact-us.marko
@@ -13,7 +13,7 @@ $ const { id, alias, name, pageNode } = data;
     <script src="https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit" async defer></script>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
 
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       <marko-web-page-wrapper>

--- a/sites/minexpo.com/server/templates/website-section/index.marko
+++ b/sites/minexpo.com/server/templates/website-section/index.marko
@@ -13,14 +13,14 @@ $ const { id, alias, name, pageNode } = data;
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
       $ const adSlots = {
-          "gpt-ad-leaderboard":   GAM.getAdUnit({ name: "leaderboard", aliases }),
-        }
-       <marko-web-gam-slots slots=adSlots />
+        "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
+      }
+      <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
-    <marko-web-gam-display-ad id="gpt-ad-leaderboard" modifiers=["above-container"] />
-    <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-top-below-head" modifiers=["above-container"] />
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["above-container"] />
   </@above-container>
   <@page>
     <marko-web-query|{ nodes }|

--- a/sites/minexpo.com/server/templates/website-section/leaders.marko
+++ b/sites/minexpo.com/server/templates/website-section/leaders.marko
@@ -12,14 +12,13 @@ $ const { id, alias, name, pageNode } = data;
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
       $ const adSlots = {
-          "gpt-ad-leaderboard":   GAM.getAdUnit({ name: "leaderboard", aliases }),
-        }
-       <marko-web-gam-slots slots=adSlots />
+        "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+      }
+      <marko-web-gam-slots slots=adSlots />
     </marko-web-resolve-page>
   </@head>
   <@above-container>
-    <marko-web-gam-display-ad id="gpt-ad-leaderboard" modifiers=["above-container"] />
-    <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-top-below-head" modifiers=["above-container"] />
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["above-container"] />
   </@above-container>
   <@page>
     <marko-web-page-wrapper>


### PR DESCRIPTION
@todo configure gam and get place holder ads firing where they need to be and adjust placeholder images that I added
 - Update primary Navigation
 - Make homepage layout changes
 - Update leaders block imagery , text & colors.
 - Directory section page changes:
 -- Update left column layout for directory page
 -- Auto Select Exhibitor when no type filter is applied
 -- Adjust block & query logic to apply company filter based on this
 -- Adjust sort from newest to alpha on name only when exhibitors is selected.

![mine-directory](https://user-images.githubusercontent.com/3845869/104136179-336ee600-535a-11eb-8128-0b89359e7c76.png)


