### PR TITLE
MINExpo editorial updates

### DIFF
--- a/packages/common/components/leaders/home-page.marko
+++ b/packages/common/components/leaders/home-page.marko
@@ -2,6 +2,7 @@ import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const { site } = out.global;
 $ const expanded = defaultValue(input.expanded, false);
+$ const mediaQueryColumns = defaultValue(input.mediaQueryColumns, 2);
 
 <marko-web-leaders props={
   sectionAlias: site.get("leaders.alias"),
@@ -15,7 +16,7 @@ $ const expanded = defaultValue(input.expanded, false);
   calloutValue: site.get('leaders.title'),
   mediaQueries: [
     { prop: "open", value: "right", query: "(min-width: 1490px)" },
-    { prop: "columns", value: 2, query: "(min-width: 700px)" },
+    { prop: "columns", value: mediaQueryColumns, query: "(min-width: 700px)" },
     { prop: "displayCallout", value: false, query: "(max-width: 660px)" },
   ],
 }/>

--- a/packages/common/components/leaders/marko.json
+++ b/packages/common/components/leaders/marko.json
@@ -8,7 +8,8 @@
     },
     "common-leaders-home-page": {
       "template": "./home-page.marko",
-      "@expanded": "boolean"
+      "@expanded": "boolean",
+      "@media-query-columns": "number"
     },
     "common-leaders-contextual": {
       "template": "./contextual.marko",

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -72,7 +72,7 @@ $ const perPage = 20;
                 <marko-web-gam-display-ad id="gpt-ad-rail1" />
               </div>
               <div class="mb-block">
-                <shared-directory-categories-block title="Exibitor Filters" aliases=aliases active-id=id content-type=contentType />
+                <shared-directory-categories-block title="Category Filters" aliases=aliases active-id=id content-type=contentType />
               </div>
               <div class="mb-block">
                 <div class="content-type-facets">

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -72,11 +72,11 @@ $ const perPage = 20;
                 <marko-web-gam-display-ad id="gpt-ad-rail1" />
               </div>
               <div class="mb-block">
-                <shared-directory-categories-block aliases=aliases active-id=id content-type=contentType />
+                <shared-directory-categories-block title="Exibitor Filters" aliases=aliases active-id=id content-type=contentType />
               </div>
               <div class="mb-block">
                 <div class="content-type-facets">
-                  <h3 class="content-type-facets__title">Content Types</h3>
+                  <h3 class="content-type-facets__title">Content Filters</h3>
                   <div class="content-type-facets__list">
                     <for|key,value| in=supportedContendTypes>
                       <if(key === 'Company')>

--- a/sites/minexpo.com/config/navigation.js
+++ b/sites/minexpo.com/config/navigation.js
@@ -9,7 +9,7 @@
 // ];
 const primary = [
   { href: '/directory', label: 'Directory' },
-  { href: '/directory?type="News', label: 'News' },
+  { href: '/directory?type=News', label: 'News' },
   { href: '?javascript:void(0)', label: 'Maps' },
   { href: '?javascript:void(0)', label: 'Export Directory' },
   { href: 'https://www.MINExpo.com', label: 'MINExpo.com' },

--- a/sites/minexpo.com/config/navigation.js
+++ b/sites/minexpo.com/config/navigation.js
@@ -10,8 +10,10 @@
 const primary = [
   { href: '/directory', label: 'Directory' },
   { href: '/directory?type=News', label: 'News' },
-  { href: '?javascript:void(0)', label: 'Maps' },
-  { href: '?javascript:void(0)', label: 'Export Directory' },
+  // eslint-disable-next-line no-script-url
+  { href: 'javascript:void(0)', label: 'Maps' },
+  // eslint-disable-next-line no-script-url
+  { href: 'javascript:void(0)', label: 'Export Directory' },
   { href: 'https://www.MINExpo.com', label: 'MINExpo.com' },
 ];
 

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -43,6 +43,10 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@ascend-media/package-common/scss/common";
 @import "../../node_modules/@ascend-media/package-minexpo/scss/index";
 
+.document-container-header {
+  padding-top: 120px;
+}
+
 .site-navbar {
   &__logo {
     height: 60px;

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -66,14 +66,28 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-8 mb-block">
         <common-leaders-home-page expanded=true />
       </div>
-      <marko-web-gam-display-ad id="gpt-ad-rail2" />
+      <div class="col-lg-4 mb-block">
+        <marko-web-gam-display-ad id="gpt-ad-rail2" />
+      </div>
     </div>
-
+    <div class="row">
+      <div class="col-lg-4 col-md-6 mb-block">
+        <marko-web-gam-display-ad id="gpt-ad-rail2" />
+      </div>
+      <div class="col-lg-8 col-md-6 mb-block">
+        <marko-web-query|{ nodes }|
+          name="all-published-content"
+          params={ limit: 5, skip: 6, requiresImage: true, queryFragment }
+        >
+          <shared-content-list-flow nodes=nodes />
+        </marko-web-query>
+      </div>
+    </div>
     <div class="row">
       <div class="col">
         <marko-web-query|{ nodes }|
           name="all-published-content"
-          params={ limit: 12, skip: 6, requiresImage: true, queryFragment }
+          params={ limit: 12, skip: 11, requiresImage: true, queryFragment }
         >
           <default-theme-card-deck-flow cols=3 nodes=nodes>
             <@slot|{ node, index }|>

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -36,7 +36,7 @@ $ const { id, alias, name, pageNode } = data;
           <website-content-card-node node=nodes[0] image-width=630 title-modifiers=["large"] />
         </marko-web-element>
         <marko-web-element name="list" block-name="hero-flow">
-          <shared-directory-categories-block aliases=[] title="Exibitor By Category" description="Select a category below to view the Exibitors within the selected category." />
+          <shared-directory-categories-block aliases=[] title="Exibitors By Category" description="Select a category below to view the Exibitors within the selected category." />
         </marko-web-element>
       </marko-web-block>
 
@@ -63,11 +63,8 @@ $ const { id, alias, name, pageNode } = data;
       </div>
     </div>
     <div class="row">
-      <div class="col-lg-8 mb-block">
-        <common-leaders-home-page expanded=true />
-      </div>
-      <div class="col-lg-4 mb-block">
-        <marko-web-gam-display-ad id="gpt-ad-rail2" />
+      <div class="col mb-block">
+        <common-leaders-home-page media-query-columns=3 expanded=true />
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
 - fix nav item links
 - Update Category Filters (change from Categories)
 - Update  - Add the 300 x 600 ad position under the Featured Exhibitor area
 - Fix header/container padding for new logo size
 - Add functionality to pass media query columns count into leader home page block

![mine-home](https://user-images.githubusercontent.com/3845869/104332125-75606f00-54b5-11eb-9f9c-279b7da16460.png)
![mine-directory](https://user-images.githubusercontent.com/3845869/104332135-77c2c900-54b5-11eb-8c63-e104c36d2bff.png)
