### PR TITLE
Expo updates

### DIFF
--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -124,7 +124,7 @@ $ const perPage = 20;
                       <@header>
                         <if('Company' === contentType)>
                           <if(p.page > 1)>${supportedContendTypes[contentType]} in ${section.name}: Page ${p.page}</if>
-                          <else>${supportedContendTypes[contentType]} in ${section.name}</else>
+                          <else>All ${supportedContendTypes[contentType]}s Alphabetically</else>
                         </if>
                         <else>
                           <if(p.page > 1)>${section.name}: Page ${p.page}</if>
@@ -134,6 +134,7 @@ $ const perPage = 20;
                       <@nodes nodes=nodes>
                         <@slot|{ node }|>
                           <minexpo-company-node
+                            with-section=false
                             node=node
                             modifiers=["content-list"]
                           >

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -29,11 +29,13 @@ $theme-site-footer-secondary-bg-color: #fff;
 $theme-load-more-button-background-color: $dark-bg-color;
 $theme-load-more-button-border-color: $dark-bg-color;
 
-$leaders-primary-color: #51659e;
+$leaders-primary-color: $primary;
 $leaders-primary-color-light: $light-bg-color;
 $leaders-accent-color: $dark-bg-color;
 
-$leaders-header-bg-color: #51659e;
+$leaders-header-bg-color: $primary;
+
+$theme-card-header-background-color: $primary;
 
 $theme-site-header-breakpoints: (
   hide-secondary: 790px,
@@ -80,7 +82,7 @@ $theme-site-header-breakpoints: (
   &__description {
     padding: 10px;
     margin: 10px 0;
-    border-bottom: solid $gray-100;
+    border-bottom: solid $primary 2px;
   }
 }
 

--- a/sites/minexpo.com/server/templates/index.marko
+++ b/sites/minexpo.com/server/templates/index.marko
@@ -36,7 +36,7 @@ $ const { id, alias, name, pageNode } = data;
           <website-content-card-node node=nodes[0] image-width=630 title-modifiers=["large"] />
         </marko-web-element>
         <marko-web-element name="list" block-name="hero-flow">
-          <shared-directory-categories-block aliases=[] title="Exibitors By Category" description="Select a category below to view the Exibitors within the selected category." />
+          <shared-directory-categories-block aliases=[] title="Search Exhibitors By Categoryy" description="Select a category below to view exhibitors within the selected category." />
         </marko-web-element>
       </marko-web-block>
 
@@ -74,9 +74,16 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-8 col-md-6 mb-block">
         <marko-web-query|{ nodes }|
           name="all-published-content"
-          params={ limit: 5, skip: 6, requiresImage: true, queryFragment }
+          params={ limit: 4, skip: 6, requiresImage: true, queryFragment }
         >
-          <shared-content-list-flow nodes=nodes />
+        <default-theme-card-deck-flow cols=2 nodes=nodes>
+          <@slot|{ node, index }|>
+            <website-content-card-node
+              image-width=340
+              node=node
+            />
+          </@slot>
+        </default-theme-card-deck-flow>
         </marko-web-query>
       </div>
     </div>
@@ -84,7 +91,7 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col">
         <marko-web-query|{ nodes }|
           name="all-published-content"
-          params={ limit: 12, skip: 11, requiresImage: true, queryFragment }
+          params={ limit: 12, skip: 10, requiresImage: true, queryFragment }
         >
           <default-theme-card-deck-flow cols=3 nodes=nodes>
             <@slot|{ node, index }|>

--- a/sites/minexpo.com/server/templates/website-section/leaders.marko
+++ b/sites/minexpo.com/server/templates/website-section/leaders.marko
@@ -23,29 +23,11 @@ $ const { id, alias, name, pageNode } = data;
   <@page>
     <marko-web-page-wrapper>
       <@section>
-        <div class="leaders-index-page__header-wrapper">
-          <div class="leaders-index-page__logo">
-            <marko-web-img
-              src=site.get("leaders.header.imgSrc")
-              alt=site.get("leaders.title")
-            />
-          </div>
-          <div class="leaders-index-page__header">
-            <h1 class="leaders-index-page__title">
-              ${site.get("leaders.title")}
-            </h1>
-            <div class="leaders-index-page__description">
-              <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
-            </div>
-          </div>
-          <div class="leaders-index-page__body">
-            <!-- <p>We hope you'll find this directory of packaging machinery and materials vendors to be a helpful resource. For each participating supplier, you'll find a comprehensive company and product profile page to help you make more informed decisions.</p>
-            <p>You'll be pleased to know that our annual Leaders in Packaging program also supports packaging education via a tuition scholarship for students pursuing degrees that will prepare them for a career in packaging. Scholarships have been awarded to students at <a href="/13359570">Clemson University</a>, <a href="/13361275">Missouri University of Science and Technology</a>, <a href="/13363639">Virginia Tech</a>, <a href="/13366329">Michigan State</a>, <a href="/13368828">Cal Poly</a>, <a href="/13371963">Rutgers</a>, <a href="/13374554">Rochester Institute of Technology</a> and the <a href="/21109517">University of Florida, Packaging Engineering Program</a>. 2020 will be our tenth year of supporting education with the “Future Leaders in Packaging Scholarship.” For more information about this scholarship, please contact Publisher Joe Angel at <a href="mailto:jangel@pmmimediagroup.com">jangel@pmmimediagroup.com</a>.</p> -->
-          </div>
+      <div class="row">
+        <div class="col mb-block">
+          <common-leaders-home-page media-query-columns=3 expanded=true />
         </div>
-      </@section>
-      <@section>
-        <common-leaders-all />
+      </div>
       </@section>
     </marko-web-page-wrapper>
   </@page>


### PR DESCRIPTION
- adjust color and css
- adjust text and content display on homepage
- use leaders block template on leaders landing page
- adjust exhibitors title & display on directory page

![Screen Shot 2021-01-18 at 9 27 56 AM](https://user-images.githubusercontent.com/3845869/104934500-d1bd0600-596f-11eb-89ec-60dd156694b9.png)
![Screen Shot 2021-01-18 at 9 28 04 AM](https://user-images.githubusercontent.com/3845869/104934509-d4b7f680-596f-11eb-9f48-251d58ac0a47.png)
![Screen Shot 2021-01-18 at 9 28 23 AM](https://user-images.githubusercontent.com/3845869/104934515-d5508d00-596f-11eb-8e56-8251789bb646.png)
