### PR TITLE
Update content lading pages

### DIFF
--- a/packages/bulletin/components/layouts/magazine/issue.marko
+++ b/packages/bulletin/components/layouts/magazine/issue.marko
@@ -37,7 +37,7 @@ $ const { issue } = input;
   <@section>
     <marko-web-query|{ nodes }|
       name="magazine-scheduled-content"
-      params={ issueId: issue.id, excludeSectionNames: ["Cover Stroy", "The Leading Edge"], limit: 100, queryFragment }
+      params={ issueId: issue.id, excludeSectionNames: ["Cover Story", "The Leading Edge"], limit: 100, queryFragment }
     >
       <default-theme-card-deck-flow cols=3 nodes=nodes>
         <@slot|{ node, index }|>

--- a/packages/bulletin/components/layouts/magazine/issue.marko
+++ b/packages/bulletin/components/layouts/magazine/issue.marko
@@ -20,12 +20,12 @@ $ const { issue } = input;
     <marko-web-block name="hero-flow">
       <marko-web-element name="hero" block-name="hero-flow">
         <marko-web-query|{ nodes }| name="magazine-scheduled-content" collapsible=false params={ issueId: issue.id, includeSectionNames: ["Cover Story"], limit: 1, queryFragment }>
-          <shared-content-hero-node use-placehoder=false block-name="hero-flow" node=nodes[0] with-attribution=true flush-y=true />
+          <shared-content-hero-node use-placehoder=false block-name="hero-flow" node=nodes[0] with-attribution=false flush-y=true />
         </marko-web-query>
       </marko-web-element>
       <marko-web-element name="list" block-name="hero-flow">
         <marko-web-query|{ nodes }| name="magazine-scheduled-content" collapsible=false params={ issueId: issue.id, includeSectionNames: ["The Leading Edge"], queryFragment }>
-          <shared-content-list-flow nodes=nodes inner-justified=false flush-x=false flush-y=false>
+          <shared-content-list-flow nodes=nodes inner-justified=true flush-x=false flush-y=false>
             <@header>Leading Edge</@header>
             <@node image-position="right" with-section=false with-dates=false with-teaser=true />
           </shared-content-list-flow>

--- a/packages/bulletin/loaders/content-latest-issue-with-content.js
+++ b/packages/bulletin/loaders/content-latest-issue-with-content.js
@@ -35,7 +35,10 @@ const getIssue = async (apolloClient, {
   `;
   const variables = { input };
   const { data } = await apolloClient.query({ query, variables });
-  if (!data || !data.contentMagazineSchedules) return { nodes: [] };
+  if (!data
+      || !data.contentMagazineSchedules
+      || !data.contentMagazineSchedules.edges.length
+  ) return null;
   const nodes = data.contentMagazineSchedules.edges
     .map(edge => (edge && edge.node ? edge.node : null))
     .filter(c => c);
@@ -53,6 +56,7 @@ module.exports = async (apolloClient, {
   contentId,
 } = {}) => {
   const issue = await getIssue(apolloClient, { contentId });
+  if (!issue) return { issue: null, issueContent: { nodes: [] } };
   const latestIssueId = issue.id;
   const issueContent = await loadIssueContent(apolloClient, {
     limit: 100,

--- a/packages/bulletin/templates/content/contact.marko
+++ b/packages/bulletin/templates/content/contact.marko
@@ -1,0 +1,119 @@
+import { get } from "@parameter1/base-cms-object-path";
+import contentLatestIssueWithContentLoader from "../../loaders/content-latest-issue-with-content";
+import queryFragment from "@ascend-media/package-shared/graphql/fragments/content-list";
+
+$ const { apollo } = out.global;
+$ const { id, type, pageNode } = data;
+$ const issuePromise = contentLatestIssueWithContentLoader(apollo, { contentId: id });
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
+  </@head>
+
+  <@page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }|
+              class="col-lg-8 mb-3 mb-lg-0"
+              modifiers=[type]
+              attrs={ "data-gallery-id": id }
+            >
+              <marko-web-element name="content-header" block-name=blockName>
+                <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+                <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+                <default-theme-content-attribution obj=content />
+                <hr>
+              </marko-web-element>
+              $ const bodyId = `content-body-${id}`;
+              <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+            </default-theme-page-contents>
+
+            <aside class="col-lg-4 page-rail">
+              <marko-web-query|{ nodes }|
+                name="all-author-content"
+                params={
+                  contactId: content.id,
+                  limit: 2,
+                  queryFragment,
+                  withSite: true,
+                }
+              >
+                <shared-content-list-flow
+                  nodes=nodes
+                  inner-justified=false
+                  flush-y=true
+                  flush-x=false
+                  modifiers=["rows", "related-content"]
+                >
+                  <@header>Latest by ${content.name}</@header>
+
+                  <@node
+                    modifiers=["related-content"]
+                    with-dates=false
+                    with-teaser=true
+                    display-image=false
+                    with-attribution=false
+                    with-section=false
+                  >
+                    <@title modifiers=["small"] />
+                  </@node>
+                </shared-content-list-flow>
+              </marko-web-query>
+            </aside>
+          </div>
+        </@section>
+        <@section>
+          <marko-web-query|{ nodes }|
+            name="all-author-content"
+            params={
+              contactId: content.id,
+              limit: 12,
+              skip: 2,
+              queryFragment,
+              withSite: true,
+            }
+          >
+            <hr />
+            <div class="page-wrapper__title--issue-name">More by ${content.name}</div>
+            <hr class="page-wrapper__above-title">
+            <default-theme-card-deck-flow cols=3 nodes=nodes>
+              <@slot|{ node, index }|>
+                <shared-content-card-node node=node with-section=false with-attribution=false />
+              </@slot>
+            </default-theme-card-deck-flow>
+          </marko-web-query>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+  <@below-page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+        <marko-web-query|{ nodes }|
+          name="all-author-content"
+          params={
+            contactId: content.id,
+            limit: 12,
+            skip: 14,
+            queryFragment,
+            withSite: true,
+          }
+        >
+          <hr />
+          <div class="page-wrapper__title--issue-name">More by ${content.name}</div>
+          <hr class="page-wrapper__above-title">
+          <default-theme-card-deck-flow cols=3 nodes=nodes>
+            <@slot|{ node, index }|>
+              <shared-content-card-node node=node with-section=false with-attribution=false />
+            </@slot>
+          </default-theme-card-deck-flow>
+        </marko-web-query>
+    </marko-web-resolve-page>
+  </@below-page>
+</marko-web-content-page-layout>

--- a/packages/bulletin/templates/content/index.marko
+++ b/packages/bulletin/templates/content/index.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import contentLatestIssueWithContentLoader from "../../loaders/content-latest-issue-with-content";
+import queryFragment from "@ascend-media/package-shared/graphql/fragments/content-list";
 
 $ const { apollo } = out.global;
 $ const { id, type, pageNode } = data;
@@ -14,7 +15,6 @@ $ const issuePromise = contentLatestIssueWithContentLoader(apollo, { contentId: 
   </@head>
 
   <@page>
-
     <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       <marko-web-page-wrapper>
         <@section>
@@ -25,11 +25,13 @@ $ const issuePromise = contentLatestIssueWithContentLoader(apollo, { contentId: 
               attrs={ "data-gallery-id": id }
             >
               <marko-web-element name="content-header" block-name=blockName>
-                <div class="page-wrapper__published">
-                  Published:
-                  <marko-web-content-published tag="span" obj=content />
-                </div>
-                <hr class="page-wrapper__above-title">
+                <if('contact' !== type)>
+                  <div class="page-wrapper__published">
+                    Published:
+                    <marko-web-content-published tag="span" obj=content />
+                  </div>
+                  <hr class="page-wrapper__above-title">
+                </if>
                 <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
                 <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
                 <default-theme-content-attribution obj=content />
@@ -41,39 +43,124 @@ $ const issuePromise = contentLatestIssueWithContentLoader(apollo, { contentId: 
             </default-theme-page-contents>
 
             <aside class="col-lg-4 page-rail">
-              <marko-web-resolve|{ resolved }| promise=issuePromise>
-                $ const { issue, issueContent } = resolved;
+              <if('contact' === type)>
+              <marko-web-query|{ nodes }|
+                name="all-author-content"
+                params={
+                  contactId: content.id,
+                  limit: 2,
+                  queryFragment,
+                  withSite: true,
+                }
+              >
                 <shared-content-list-flow
-                  nodes=issueContent.nodes.slice(0,3)
+                  nodes=nodes
                   inner-justified=false
+                  flush-y=true
                   flush-x=false
-                  flush-y=false
+                  modifiers=["rows", "related-content"]
                 >
-                  <@header>More Articles</@header>
-                  <@node with-dates=false with-teaser=false display-image=false with-attribution=false with-section=false>
-                  <@title modifiers=["small"] />
+                  <@header>Latest by ${content.name}</@header>
+
+                  <@node
+                    modifiers=["related-content"]
+                    with-dates=false
+                    with-teaser=true
+                    display-image=false
+                    with-attribution=false
+                    with-section=false
+                  >
+                    <@title modifiers=["small"] />
                   </@node>
                 </shared-content-list-flow>
-                <bulletin-magazine-latest-issue-node card=true flush=false card=false node=issue />
-              </marko-web-resolve>
+              </marko-web-query>
+              </if>
+              <else>
+                <marko-web-resolve|{ resolved }| promise=issuePromise>
+                  $ const { issue, issueContent } = resolved;
+                  <if(issue)>
+                    <shared-content-list-flow
+                      nodes=issueContent.nodes.slice(0,3)
+                      inner-justified=false
+                      flush-x=false
+                      flush-y=false
+                    >
+                      <@header>More Articles</@header>
+                      <@node with-dates=false with-teaser=false display-image=false with-attribution=false with-section=false>
+                        <@title modifiers=["small"] />
+                      </@node>
+                    </shared-content-list-flow>
+                    <bulletin-magazine-latest-issue-node card=true flush=false card=false node=issue />
+                  </if>
+                </marko-web-resolve>
+              </else>
             </aside>
           </div>
         </@section>
         <@section>
-          <marko-web-resolve|{ resolved }| promise=issuePromise>
-            $ const { issue, issueContent } = resolved;
-            <hr />
-            <div class="page-wrapper__title--issue-name">More from ${issue.name}</div>
-            <hr class="page-wrapper__above-title">
-            <default-theme-card-deck-flow cols=3 nodes=issueContent.nodes.slice(3)>
-              <@slot|{ node, index }|>
-                <shared-content-card-node node=node with-section=false with-attribution=false />
-              </@slot>
-            </default-theme-card-deck-flow>
-          </marko-web-resolve>
+          <if('contact' === type)>
+            <marko-web-query|{ nodes }|
+              name="all-author-content"
+              params={
+                contactId: content.id,
+                limit: 12,
+                skip: 2,
+                queryFragment,
+                withSite: true,
+              }
+            >
+              <hr />
+              <div class="page-wrapper__title--issue-name">More by ${content.name}</div>
+              <hr class="page-wrapper__above-title">
+              <default-theme-card-deck-flow cols=3 nodes=nodes>
+                <@slot|{ node, index }|>
+                  <shared-content-card-node node=node with-section=false with-attribution=false />
+                </@slot>
+              </default-theme-card-deck-flow>
+            </marko-web-query>
+          </if>
+          <else>
+            <marko-web-resolve|{ resolved }| promise=issuePromise>
+              $ const { issue, issueContent } = resolved;
+              <if(issue)>
+                <hr />
+                <div class="page-wrapper__title--issue-name">More from ${issue.name}</div>
+                <hr class="page-wrapper__above-title">
+                <default-theme-card-deck-flow cols=3 nodes=issueContent.nodes.slice(3)>
+                  <@slot|{ node, index }|>
+                    <shared-content-card-node node=node with-section=false with-attribution=false />
+                  </@slot>
+                </default-theme-card-deck-flow>
+              </if>
+            </marko-web-resolve>
+          </else>
         </@section>
-
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
+  <@below-page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      <if('contact' === type)>
+        <marko-web-query|{ nodes }|
+          name="all-author-content"
+          params={
+            contactId: content.id,
+            limit: 12,
+            skip: 14,
+            queryFragment,
+            withSite: true,
+          }
+        >
+          <hr />
+          <div class="page-wrapper__title--issue-name">More by ${content.name}</div>
+          <hr class="page-wrapper__above-title">
+          <default-theme-card-deck-flow cols=3 nodes=nodes>
+            <@slot|{ node, index }|>
+              <shared-content-card-node node=node with-section=false with-attribution=false />
+            </@slot>
+          </default-theme-card-deck-flow>
+        </marko-web-query>
+      </if>
+    </marko-web-resolve-page>
+  </@below-page>
 </marko-web-content-page-layout>

--- a/packages/bulletin/templates/content/index.marko
+++ b/packages/bulletin/templates/content/index.marko
@@ -1,6 +1,5 @@
 import { get } from "@parameter1/base-cms-object-path";
 import contentLatestIssueWithContentLoader from "../../loaders/content-latest-issue-with-content";
-import queryFragment from "@ascend-media/package-shared/graphql/fragments/content-list";
 
 $ const { apollo } = out.global;
 $ const { id, type, pageNode } = data;
@@ -25,13 +24,11 @@ $ const issuePromise = contentLatestIssueWithContentLoader(apollo, { contentId: 
               attrs={ "data-gallery-id": id }
             >
               <marko-web-element name="content-header" block-name=blockName>
-                <if('contact' !== type)>
-                  <div class="page-wrapper__published">
-                    Published:
-                    <marko-web-content-published tag="span" obj=content />
-                  </div>
-                  <hr class="page-wrapper__above-title">
-                </if>
+                <div class="page-wrapper__published">
+                  Published:
+                  <marko-web-content-published tag="span" obj=content />
+                </div>
+                <hr class="page-wrapper__above-title">
                 <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
                 <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
                 <default-theme-content-attribution obj=content />
@@ -43,124 +40,42 @@ $ const issuePromise = contentLatestIssueWithContentLoader(apollo, { contentId: 
             </default-theme-page-contents>
 
             <aside class="col-lg-4 page-rail">
-              <if('contact' === type)>
-              <marko-web-query|{ nodes }|
-                name="all-author-content"
-                params={
-                  contactId: content.id,
-                  limit: 2,
-                  queryFragment,
-                  withSite: true,
-                }
-              >
-                <shared-content-list-flow
-                  nodes=nodes
-                  inner-justified=false
-                  flush-y=true
-                  flush-x=false
-                  modifiers=["rows", "related-content"]
-                >
-                  <@header>Latest by ${content.name}</@header>
-
-                  <@node
-                    modifiers=["related-content"]
-                    with-dates=false
-                    with-teaser=true
-                    display-image=false
-                    with-attribution=false
-                    with-section=false
+              <marko-web-resolve|{ resolved }| promise=issuePromise>
+                $ const { issue, issueContent } = resolved;
+                <if(issue)>
+                  <shared-content-list-flow
+                    nodes=issueContent.nodes.slice(0,3)
+                    inner-justified=false
+                    flush-x=false
+                    flush-y=false
                   >
-                    <@title modifiers=["small"] />
-                  </@node>
-                </shared-content-list-flow>
-              </marko-web-query>
-              </if>
-              <else>
-                <marko-web-resolve|{ resolved }| promise=issuePromise>
-                  $ const { issue, issueContent } = resolved;
-                  <if(issue)>
-                    <shared-content-list-flow
-                      nodes=issueContent.nodes.slice(0,3)
-                      inner-justified=false
-                      flush-x=false
-                      flush-y=false
-                    >
-                      <@header>More Articles</@header>
-                      <@node with-dates=false with-teaser=false display-image=false with-attribution=false with-section=false>
-                        <@title modifiers=["small"] />
-                      </@node>
-                    </shared-content-list-flow>
-                    <bulletin-magazine-latest-issue-node card=true flush=false card=false node=issue />
-                  </if>
-                </marko-web-resolve>
-              </else>
+                    <@header>More Articles</@header>
+                    <@node with-dates=false with-teaser=false display-image=false with-attribution=false with-section=false>
+                      <@title modifiers=["small"] />
+                    </@node>
+                  </shared-content-list-flow>
+                  <bulletin-magazine-latest-issue-node card=true flush=false card=false node=issue />
+                </if>
+              </marko-web-resolve>
             </aside>
           </div>
         </@section>
         <@section>
-          <if('contact' === type)>
-            <marko-web-query|{ nodes }|
-              name="all-author-content"
-              params={
-                contactId: content.id,
-                limit: 12,
-                skip: 2,
-                queryFragment,
-                withSite: true,
-              }
-            >
+          <marko-web-resolve|{ resolved }| promise=issuePromise>
+            $ const { issue, issueContent } = resolved;
+            <if(issue)>
               <hr />
-              <div class="page-wrapper__title--issue-name">More by ${content.name}</div>
+              <div class="page-wrapper__title--issue-name">More from ${issue.name}</div>
               <hr class="page-wrapper__above-title">
-              <default-theme-card-deck-flow cols=3 nodes=nodes>
+              <default-theme-card-deck-flow cols=3 nodes=issueContent.nodes.slice(3)>
                 <@slot|{ node, index }|>
                   <shared-content-card-node node=node with-section=false with-attribution=false />
                 </@slot>
               </default-theme-card-deck-flow>
-            </marko-web-query>
-          </if>
-          <else>
-            <marko-web-resolve|{ resolved }| promise=issuePromise>
-              $ const { issue, issueContent } = resolved;
-              <if(issue)>
-                <hr />
-                <div class="page-wrapper__title--issue-name">More from ${issue.name}</div>
-                <hr class="page-wrapper__above-title">
-                <default-theme-card-deck-flow cols=3 nodes=issueContent.nodes.slice(3)>
-                  <@slot|{ node, index }|>
-                    <shared-content-card-node node=node with-section=false with-attribution=false />
-                  </@slot>
-                </default-theme-card-deck-flow>
-              </if>
-            </marko-web-resolve>
-          </else>
+            </if>
+          </marko-web-resolve>
         </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
-  <@below-page>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
-      <if('contact' === type)>
-        <marko-web-query|{ nodes }|
-          name="all-author-content"
-          params={
-            contactId: content.id,
-            limit: 12,
-            skip: 14,
-            queryFragment,
-            withSite: true,
-          }
-        >
-          <hr />
-          <div class="page-wrapper__title--issue-name">More by ${content.name}</div>
-          <hr class="page-wrapper__above-title">
-          <default-theme-card-deck-flow cols=3 nodes=nodes>
-            <@slot|{ node, index }|>
-              <shared-content-card-node node=node with-section=false with-attribution=false />
-            </@slot>
-          </default-theme-card-deck-flow>
-        </marko-web-query>
-      </if>
-    </marko-web-resolve-page>
-  </@below-page>
 </marko-web-content-page-layout>

--- a/sites/bulletin.entnet.org/config/site.js
+++ b/sites/bulletin.entnet.org/config/site.js
@@ -6,7 +6,7 @@ module.exports = {
   logos,
   navigation,
   gam,
-  company: 'Ascend Media',
+  company: 'American Academy of Otolaryngology–Head and Neck Surgery',
   socialMediaLinks: [],
   gtm: {
     containerId: 'GTM-5XS5Z5K',

--- a/sites/bulletin.entnet.org/server/routes/content.js
+++ b/sites/bulletin.entnet.org/server/routes/content.js
@@ -1,8 +1,13 @@
 const { withContent } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-shared/graphql/fragments/content-page');
+const contact = require('@ascend-media/package-bulletin/templates/content/contact');
 const content = require('@ascend-media/package-bulletin/templates/content');
 
 module.exports = (app) => {
+  app.get('/*?contact/:id(\\d{8})*', withContent({
+    template: contact,
+    queryFragment,
+  }));
   app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,

--- a/sites/bulletin.entnet.org/server/routes/magazine.js
+++ b/sites/bulletin.entnet.org/server/routes/magazine.js
@@ -15,6 +15,11 @@ module.exports = (app) => {
     queryFragment: publicationFragment,
   }));
 
+  app.get('/magazine/48620', (req, res) => {
+    const to = 'https://bulletin.entnet.org/books/2021-january-aao-hns-bulletin-special-edition/';
+    res.redirect(301, to);
+  });
+
   app.get('/magazine/:id(\\d+)', withMagazineIssue({
     template: issue,
     queryFragment: issueFragment,


### PR DESCRIPTION
Add new route and template for contact content type.  Will now pull author content.  Also added issue check on non content type pages to account for stories being associated with an issue, but based on this sites requirements this shouldn't happen.

<img width="1175" alt="Screen Shot 2021-01-28 at 1 18 06 PM" src="https://user-images.githubusercontent.com/3845869/106187605-74913380-616b-11eb-85c1-4def441ce4e4.png">
<img width="1168" alt="Screen Shot 2021-01-28 at 1 18 14 PM" src="https://user-images.githubusercontent.com/3845869/106187610-76f38d80-616b-11eb-8418-7026ece3b5e9.png">
