### PR TITLE
Update default section pages & ISC homepage to us website-section-content loader

### DIFF
--- a/packages/shared/loaders/website-section-content.js
+++ b/packages/shared/loaders/website-section-content.js
@@ -3,8 +3,8 @@ const defaultFragment = require('../graphql/fragments/content-list');
 
 const loadFeaturedContent = async (apolloClient, params = {}) => {
   const defaults = {
-    limit: 3,
-    optionName: 'Featured Content',
+    limit: 5,
+    optionName: 'Pinned',
     queryFragment: defaultFragment,
   };
 
@@ -16,8 +16,8 @@ const loadFeaturedContent = async (apolloClient, params = {}) => {
 
 const loadStandardContent = async (apolloClient, params = {}) => {
   const defaults = {
-    limit: 4,
-    optionName: ['Featured Content', 'Standard'],
+    limit: 5,
+    optionName: ['Standard'],
     queryFragment: defaultFragment,
   };
 

--- a/packages/shared/templates/website-section/index.marko
+++ b/packages/shared/templates/website-section/index.marko
@@ -1,7 +1,11 @@
+import { getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
 import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { isFunction } from "@parameter1/base-cms-utils";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import websiteSectionContentLoader from "../../loaders/website-section-content";
 import queryFragment from "../../graphql/fragments/content-list";
 
-$ const { GAM } = out.global;
+$ const { GAM, apollo } = out.global;
 
 $ const {
   id,
@@ -10,54 +14,90 @@ $ const {
   pageNode,
 } = input;
 
-<marko-web-website-section-page-layout id=id alias=alias name=name>
-  <@head>
-    <marko-web-gtm-website-section-context|{ context }| alias=alias>
-      <marko-web-gtm-push data=context />
-    </marko-web-gtm-website-section-context>
-  </@head>
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
+});
 
-  <@page>
-    <marko-web-resolve-page|{ data: section }| node=pageNode>
-      $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-define-display-ad
-        ...GAM.getAdUnit({ name: "lb1", aliases })
-        modifiers=["top-of-page", "max-width-970", "center", "paid"]
-        collapse-before-ad-fetch=true
-        with-wrapper=true
-      />
+$ const promise = websiteSectionContentLoader(apollo, {
+  sectionId: id,
+  featuredParams: {
+    optionName: ["Pinned"],
+    limit: 5,
+    requiresImage: true,
+    queryFragment
+  },
+  standardParams: {
+    optionName: ["Standard"],
+    limit: 10,
+    requiresImage: true,
+    queryFragment
+  },
+  withStandardQuery: true,
+});
 
-      <marko-web-query|{ nodes }|
-        name="website-optioned-content"
-        params={ sectionId: id, optionName: "Pinned", limit: 15, skip: 0, requiresImage: true, queryFragment }
-      >
-        <shared-standard-hero-block nodes=nodes.slice(0, 5) />
-        <shared-content-card-deck-flow nodes=nodes.slice(5, 10) cols=3 ad-index=4 ad-name="rail1" ad-modifiers=["paid"]>
+<marko-web-resolve|{ resolved: sectionContent }| promise=promise>
+  $ const { featured, standard } = sectionContent;
+  <marko-web-resolve|{ resolved: { data: section } }| promise=pageNode.load()>
+    $ const aliases = hierarchyAliases(section);
+    $ const slots = adSlots({ aliases });
+    <marko-web-website-section-page-layout id=id alias=alias name=name>
+      <@head>
+        <marko-web-gtm-website-section-context|{ context }| alias=alias>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-website-section-context>
+        <marko-web-gam-slots slots=slots />
+      </@head>
+
+      <@above-container>
+        <@section
+          id=section.id
+          name=section.name
+          alias=section.alias
+          logo=section.logo
+          hierarchy=section.hierarchy
+        />
+      </@above-container>
+      <@above-page>
+        <marko-web-gam-display-ad
+          id="gpt-ad-lb1"
+          slots=slots
+          class="mt-block"
+          modifiers=["max-width-970", "margin-auto-x", "center"]
+        />
+      </@above-page>
+      <@page>
+        <shared-standard-hero-block nodes=getAsArray(featured, "nodes") />
+        <shared-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 5) cols=3 ad-index=4 ad-name="rail1" ad-modifiers=["paid"]>
           <@native-x index=3 name="default" section-name="Supported Content" />
         </shared-content-card-deck-flow>
-        <shared-content-card-deck-flow nodes=nodes.slice(10, 15) cols=3 ad-index=4 ad-name="rail2" />
-      </marko-web-query>
+        <shared-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5) cols=3 ad-index=4 ad-name="rail2" />
 
-      <marko-web-gam-define-display-ad
-        ...GAM.getAdUnit({ name: "lb2", aliases })
-        modifiers=["max-width-970", "center", "paid"]
-        collapse-before-ad-fetch=true
-        with-wrapper=true
-      />
-    </marko-web-resolve-page>
-  </@page>
-  <@below-page>
-    <marko-web-resolve-page|{ data: section }| node=pageNode>
-      $ const aliases = hierarchyAliases(section);
-      <marko-web-load-more
-        component-name="shared-content-card-deck-flow"
-        component-input={ aliases, cols: 3 }
-        fragment-name="shared-content-list"
-        query-name="website-scheduled-content"
-        query-params={ sectionId: id, limit: 12, skip: 16, requiresImage: true }
-        max-pages=3
-        page-input={ for: "website-section", id }
-      />
-    </marko-web-resolve-page>
-  </@below-page>
-</marko-web-website-section-page-layout>
+        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center", "paid"] />
+
+      </@page>
+
+      <@below-page>
+        <marko-web-resolve-page|{ data: section }| node=pageNode>
+          $ const aliases = hierarchyAliases(section);
+          $ const loadMoreParams = {
+            sectionId: id,
+            optionName: ["Standard"],
+            excludeContentIds: sectionContent.ids,
+            limit: 12,
+          };
+          <marko-web-load-more
+            component-name="shared-content-card-deck-flow"
+            component-input={ aliases, cols: 3, withTeaser: false }
+            fragment-name="shared-content-list"
+            query-name="website-scheduled-content"
+            query-params=loadMoreParams
+            max-pages=3
+            page-input={ for: "website-section", id }
+          />
+        </marko-web-resolve-page>
+      </@below-page>
+
+    </marko-web-website-section-page-layout>
+  </marko-web-resolve>
+</marko-web-resolve>

--- a/sites/isc.hub.heart.org/server/templates/index.marko
+++ b/sites/isc.hub.heart.org/server/templates/index.marko
@@ -1,7 +1,11 @@
+import { getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
 import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { isFunction } from "@parameter1/base-cms-utils";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import websiteSectionContentLoader from "@ascend-media/package-shared/loaders/website-section-content";
 import queryFragment from "@ascend-media/package-shared/graphql/fragments/content-list";
 
-$ const { GAM } = out.global;
+$ const { GAM, apollo } = out.global;
 
 $ const {
   id,
@@ -15,82 +19,103 @@ $ const adSlots = ({ aliases }) => ({
   "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
 });
 
-<marko-web-website-section-page-layout id=id alias=alias name=name>
-  <@head>
-    <marko-web-gtm-website-section-context|{ context }| alias=alias>
-      <marko-web-gtm-push data=context />
-    </marko-web-gtm-website-section-context>
-    <marko-web-resolve-page|{ data: section }| node=pageNode>
-      $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-slots slots=adSlots({ aliases }) />
-    </marko-web-resolve-page>
-  </@head>
+$ const promise = websiteSectionContentLoader(apollo, {
+  sectionId: id,
+  featuredParams: {
+    optionName: ["Pinned"],
+    limit: 5,
+    requiresImage: true,
+    queryFragment
+  },
+  standardParams: {
+    optionName: ["Standard"],
+    limit: 17,
+    requiresImage: true,
+    queryFragment
+  },
+  withStandardQuery: true,
+});
+<marko-web-resolve|{ resolved: sectionContent }| promise=promise>
+  $ const { featured, standard } = sectionContent;
+  <marko-web-resolve|{ resolved: { data: section } }| promise=pageNode.load()>
+    $ const aliases = hierarchyAliases(section);
+    $ const slots = adSlots({ aliases });
+    <marko-web-website-section-page-layout id=id alias=alias name=name>
+      <@head>
+        <marko-web-gtm-website-section-context|{ context }| alias=alias>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-website-section-context>
+        <marko-web-gam-slots slots=slots />
+      </@head>
 
-  <@page>
-    <marko-web-resolve-page|{ data: section }| node=pageNode>
-      $ const aliases = hierarchyAliases(section);
+      <@above-container>
+        <@section
+          id=section.id
+          name=section.name
+          alias=section.alias
+          logo=section.logo
+          hierarchy=section.hierarchy
+        />
+      </@above-container>
+      <@above-page>
+        <marko-web-gam-display-ad
+          id="gpt-ad-lb1"
+          slots=slots
+          class="mt-block"
+          modifiers=["max-width-970", "margin-auto-x", "center"]
+        />
+      </@above-page>
+      <@page>
+        <shared-standard-hero-block nodes=featured.nodes />
 
-      <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page", "max-width-970", "center"] />
-
-      <marko-web-query|{ nodes }|
-        name="website-optioned-content"
-        params={ sectionId: id, optionName: "Pinned", limit: 10, skip: 0, requiresImage: true, queryFragment }
-      >
-        <shared-standard-hero-block nodes=nodes.slice(0, 5) />
+        <shared-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 8) cols=3 ad-index=3 ad-name="rail1" ad-modifiers=["paid"]>
+          <@native-x index=3 name="default" section-name="Supported Content" />
+        </shared-content-card-deck-flow>
 
         <div class="row">
-          <div class="col-lg-12 mb-block">
-            <shared-content-card-deck-flow nodes=nodes.slice(5, 10) cols=3 ad-index=3 ad-name="rail1" ad-modifiers=["paid"]>
-              <@native-x index=3 name="default" section-name="Supported Content" />
-            </shared-content-card-deck-flow>
-          </div>
+            <div class="col-lg-8 mb-block">
+              <shared-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 12) cols=2 with-teaser=false />
+            </div>
+            <div class="col-lg-4 mb-block page-rail">
+              <a
+                class="twitter-timeline btn btn-primary btn-block"
+                data-height="650"
+                data-theme="light"
+                href="https://twitter.com/AHAmeetings?ref_src=twsrc%5Etfw"
+                target="_blank"
+              >
+                Tweets by AHAScience
+              </a>
+              <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            </div>
         </div>
-      </marko-web-query>
 
-      <div class="row">
+        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center"] />
 
-        <marko-web-query|{ nodes }|
-          name="website-optioned-content"
-          params={ sectionId: id, optionName: "Pinned", limit: 7, skip: 10, requiresImage: true, queryFragment }
-        >
-          <div class="col-lg-12 mb-block">
-            <shared-content-card-deck-flow nodes=nodes.slice(0, 3) cols=3 with-teaser=false />
-          </div>
+        <shared-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(12) cols=3 ad-index=4 ad-name="rail2" />
+      </@page>
 
-          <div class="col-lg-8 mb-block">
-            <shared-content-card-deck-flow nodes=nodes.slice(3, 7) cols=2 with-teaser=false />
-          </div>
-          <div class="col-lg-4 mb-block page-rail">
-            <a
-              class="twitter-timeline btn btn-primary btn-block"
-              data-height="650"
-              data-theme="light"
-              href="https://twitter.com/AHAmeetings?ref_src=twsrc%5Etfw"
-              target="_blank"
-            >
-              Tweets by AHAScience
-            </a>
-            <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-          </div>
-        </marko-web-query>
-      </div>
+      <@below-page>
+        <marko-web-resolve-page|{ data: section }| node=pageNode>
+          $ const aliases = hierarchyAliases(section);
+          $ const loadMoreParams = {
+            sectionId: id,
+            optionName: ["Standard"],
+            excludeContentIds: sectionContent.ids,
+            limit: 12,
+          };
+          <marko-web-load-more
+            component-name="shared-content-card-deck-flow"
+            component-input={ aliases, cols: 3, withTeaser: false }
+            fragment-name="shared-content-list"
+            query-name="website-scheduled-content"
+            query-params=loadMoreParams
+            max-pages=3
+            page-input={ for: "website-section", id }
+          />
+        </marko-web-resolve-page>
+      </@below-page>
 
-      <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center"] />
-
-    </marko-web-resolve-page>
-  </@page>
-  <@below-page>
-    <marko-web-resolve-page|{ data: section }| node=pageNode>
-      $ const aliases = hierarchyAliases(section);
-      <marko-web-load-more
-        component-name="shared-content-card-deck-flow"
-        component-input={ aliases, cols: 3, withTeaser: false }
-        fragment-name="shared-content-list"
-        query-name="website-scheduled-content"
-        query-params={ sectionId: id, limit: 10, skip: 17, requiresImage: true }
-        max-pages=3
-        page-input={ for: "website-section", id }
-      />
-    </marko-web-resolve-page>
-  </@below-page>
-</marko-web-website-section-page-layout>
+    </marko-web-website-section-page-layout>
+  </marko-web-resolve>
+</marko-web-resolve>


### PR DESCRIPTION
update so that the main page uses the website section page content loader logic and excludeIds in load more

![iscHome](https://user-images.githubusercontent.com/3845869/109216858-b1f0dd00-777a-11eb-8731-4aa1669cef9f.jpg)
![iscNews](https://user-images.githubusercontent.com/3845869/109216871-b5846400-777a-11eb-8188-cc8a96479d72.jpg)
