### PR TITLE
ISC homepage updates

### DIFF
--- a/sites/isc.hub.heart.org/config/navigation.js
+++ b/sites/isc.hub.heart.org/config/navigation.js
@@ -18,7 +18,7 @@ const topics = [
   // { href: '#', label: 'Claim CME', target: '_blank' },
   // { href: '#', label: 'OnDemand' },
   { href: '/previews', label: 'Previews' },
-  { href: '/archives', label: 'Archives' },
+  // { href: '/archives', label: 'Archives' },
 ];
 
 const secondary = [

--- a/sites/isc.hub.heart.org/server/templates/index.marko
+++ b/sites/isc.hub.heart.org/server/templates/index.marko
@@ -90,7 +90,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </div>
         </div>
 
-        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center"] />
+        <marko-web-gam-display-ad id="gpt-ad-lb2" class="mb-block" modifiers=["max-width-970", "margin-auto-x", "center"] />
 
         <shared-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(12) cols=3 ad-index=4 ad-name="rail2" />
       </@page>


### PR DESCRIPTION
Hide Archives link & update margin bottom on second homepage leaderboard.

<img width="598" alt="Screen Shot 2021-03-11 at 12 22 55 PM" src="https://user-images.githubusercontent.com/3845869/110835705-c1852100-8264-11eb-859d-b7a08115d564.png">
