### PR TITLE
MINExpo: Homepage Redirect, Move Menu in header & update company landing page

### DIFF
--- a/packages/minexpo/components/page-wrappers/content/leader.marko
+++ b/packages/minexpo/components/page-wrappers/content/leader.marko
@@ -149,12 +149,15 @@ $ const { id, type, content } = input;
 
   </div>
   <div class="col-lg-4 page-rail mb-3 mb-lg-0">
-    <marko-web-node-list collapsible=false class="mt-block">
+    <!-- <marko-web-node-list collapsible=false class="mt-block">
       <@header>Request More Information</@header>
       <@body>
         <shared-inquiry-block content=content with-header=false modifiers=["block"] />
       </@body>
-    </marko-web-node-list>
+    </marko-web-node-list> -->
+    <div class="mt-block">
+      <shared-directory-categories-block aliases=[] title="Search Product Categories" description="Select a category below:" />
+    </div>
 
     $ const contacts = getAsArray(content, "contacts.edges").map(({ node }) => node);
     <marko-web-node-list class="mt-block">

--- a/packages/minexpo/components/site-header.marko
+++ b/packages/minexpo/components/site-header.marko
@@ -1,0 +1,62 @@
+$ const { config, site } = out.global;
+
+$ const blockName = input.blockName || "site-header";
+
+$ const navigation = {
+  primary: site.getAsArray("navigation.primary.items"),
+  secondary: site.getAsArray("navigation.secondary.items"),
+  tertiary: site.getAsArray("navigation.tertiary.items"),
+  menu: site.getAsArray("navigation.menu"),
+};
+
+$ const tertiaryMods = ["tertiary"];
+$ if (navigation.secondary.length) tertiaryMods.push("no-left-margin");
+
+<marko-web-block
+  name=blockName
+  tag=(input.tag || "header")
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  <${input.aboveNav} />
+  <default-theme-site-navbar modifiers=["secondary"]>
+    <default-theme-site-navbar-brand title=`${config.website("name")} Homepage`>
+      <default-theme-site-navbar-logo
+        alt=config.website("name")
+        src=site.get("logos.navbar.src")
+        srcset=site.getAsArray("logos.navbar.srcset").join(",")
+      />
+    </default-theme-site-navbar-brand>
+    <default-theme-site-navbar-items
+      items=navigation.secondary
+      modifiers=["secondary"]
+      reg-enabled=input.regEnabled
+      has-user=input.hasUser
+    />
+    <default-theme-site-navbar-items
+      items=navigation.tertiary
+      modifiers=tertiaryMods
+      reg-enabled=input.regEnabled
+      has-user=input.hasUser
+    />
+    <if(navigation.menu.length)>
+      <default-theme-menu-toggle-button
+        class-name="site-navbar__toggler"
+        targets=[".site-menu"]
+        toggle-class="site-menu--open"
+        icon-modifiers=["lg"]
+      />
+    </if>
+  </default-theme-site-navbar>
+
+  <default-theme-site-navbar modifiers=["primary"]>
+    <default-theme-site-navbar-items
+      items=navigation.primary
+      modifiers=["primary"]
+      reg-enabled=input.regEnabled
+      has-user=input.hasUser
+    />
+  </default-theme-site-navbar>
+  <${input.belowNav} />
+</marko-web-block>

--- a/packages/minexpo/marko.json
+++ b/packages/minexpo/marko.json
@@ -5,5 +5,17 @@
   ],
   "<pagination-controls>": {
     "template": "./components/pagination-controls.marko"
+  },
+  "<minexpo-site-header>": {
+    "template": "./components/site-header.marko",
+    "<above-nav>": {},
+    "<below-nav>": {},
+    "@attrs": "object",
+    "@block-name": "string",
+    "@class": "string",
+    "@has-user": "boolean",
+    "@modifiers": "array",
+    "@reg-enabled": "boolean",
+    "@tag": "string"
   }
 }

--- a/packages/minexpo/scss/index.scss
+++ b/packages/minexpo/scss/index.scss
@@ -60,3 +60,23 @@
     }
   }
 }
+
+.site-navbar {
+  &__items {
+    &--secondary {
+      flex-grow: 1;
+    }
+  }
+}
+
+.site-menu {
+  $self: &;
+  top: 120px;
+  &--right {
+    right: 0;
+    transform: translateX(#{$theme-site-navbar-menu-width});
+    &#{ $self }--open {
+      transform: translateX(0);
+    }
+  }
+}

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -25,11 +25,6 @@ $ const {
 } = input;
 $ const perPage = 20;
 
-<!-- If Loaded on the homepage reset the alias to the default directory alias -->
-$ if (alias === 'home') {
-  pageNode.variables.input.alias = 'directory'
-}
-
 <marko-web-resolve-page|{ data: section }| node=pageNode>
   $ let queryParams = {
     sectionId: section.id,

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -25,6 +25,11 @@ $ const {
 } = input;
 $ const perPage = 20;
 
+<!-- If Loaded on the homepage reset the alias to the default directory alias -->
+$ if (alias === 'home') {
+  pageNode.variables.input.alias = 'directory'
+}
+
 <marko-web-resolve-page|{ data: section }| node=pageNode>
   $ let queryParams = {
     sectionId: section.id,

--- a/sites/minexpo.com/server/components/document.marko
+++ b/sites/minexpo.com/server/components/document.marko
@@ -20,8 +20,8 @@ $ const { site } = out.global;
     <common-leaders-dropdown-portal />
     <marko-web-reveal-ad-listener />
     <marko-web-gtm-track-load-more />
-    <default-theme-site-header />
-    <default-theme-site-menu />
+    <minexpo-site-header />
+    <default-theme-site-menu modifiers=["right"] />
     <div class="document-container-header">
       <${input.aboveContainer} />
     </div>

--- a/sites/minexpo.com/server/routes/home.js
+++ b/sites/minexpo.com/server/routes/home.js
@@ -1,12 +1,13 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 // const home = require('../templates/index');
-const home = require('../templates/index');
+// const home = require('../templates/index');
+const directory = require('@ascend-media/package-minexpo/templates/website-section/directory');
 const queryFragment = require('../graphql/fragments/website-section-page');
 
 module.exports = (app) => {
   app.get('/', withWebsiteSection({
     aliasResolver: () => 'home',
-    template: home,
+    template: directory,
     queryFragment,
   }));
 };

--- a/sites/minexpo.com/server/routes/home.js
+++ b/sites/minexpo.com/server/routes/home.js
@@ -1,13 +1,15 @@
-const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
+// const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 // const home = require('../templates/index');
-// const home = require('../templates/index');
-const directory = require('@ascend-media/package-minexpo/templates/website-section/directory');
-const queryFragment = require('../graphql/fragments/website-section-page');
+// const queryFragment = require('../graphql/fragments/website-section-page');
 
 module.exports = (app) => {
-  app.get('/', withWebsiteSection({
-    aliasResolver: () => 'home',
-    template: directory,
-    queryFragment,
-  }));
+  // app.get('/', withWebsiteSection({
+  //   aliasResolver: () => 'home',
+  //   template: home,
+  //   queryFragment,
+  // }));
+  app.get('/', (req, res) => {
+    const to = '/directory';
+    res.redirect(301, to);
+  });
 };

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -79,7 +79,7 @@ $theme-site-header-breakpoints: (
 }
 .ldp {
   &__social {
-    > .btn-primary {
+    a:not([href]):not([tabindex]) {
       color: $white;
     }
   }

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -77,6 +77,13 @@ $theme-site-header-breakpoints: (
     line-height: 1;
   }
 }
+.ldp {
+  &__social {
+    > .btn-primary {
+      color: $white;
+    }
+  }
+}
 .search-form {
   margin-right: 0;
 


### PR DESCRIPTION
 - Point homepage at /directory
 - move menu icon and menu flyout to right side
 - Make visit site button text white
 - swap out RMI for product category block
![Screen Shot 2021-03-16 at 12 57 52 PM](https://user-images.githubusercontent.com/3845869/111357376-3eded600-8657-11eb-9879-2ad47d346a78.png)
