### PR TITLE
MINExpo updates

### DIFF
--- a/packages/common/components/leaders/all.marko
+++ b/packages/common/components/leaders/all.marko
@@ -15,6 +15,7 @@ $ const displayViewAll = defaultValue(input.displayViewAll, true);
   offsetTop: 50,
   viewAllHref: '/leaders',
   mediaQueries: [
+    { prop: "open", value: "right", query: "(min-width: 1490px)" },
     { prop: "columns", value: 2, query: "(max-width: 991px)" },
     { prop: "columns", value: 1, query: "(max-width: 700px)" },
   ],

--- a/packages/common/components/leaders/directory-page.marko
+++ b/packages/common/components/leaders/directory-page.marko
@@ -1,0 +1,24 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { site } = out.global;
+$ const expanded = defaultValue(input.expanded, false);
+$ const viewAllText = defaultValue(site.get("leaders.viewAllText"), 'View All Companies &gt;');
+$ const displayViewAll = defaultValue(input.displayViewAll, true);
+
+<marko-web-leaders props={
+  sectionAlias: site.get("leaders.alias"),
+  open: null,
+  expanded,
+  viewAllText,
+  headerImgSrc: site.get("leaders.header.imgSrc"),
+  headerImgAlt: site.get("leaders.title"),
+  columns: 1,
+  offsetTop: 50,
+  viewAllHref: '/leaders',
+  displayViewAll,
+  displayCallout: false,
+  calloutValue: site.get('leaders.title'),
+  mediaQueries: [
+    { prop: "columns", value: 1, query: "(min-width: 700px)" },
+  ],
+}/>

--- a/packages/common/components/leaders/marko.json
+++ b/packages/common/components/leaders/marko.json
@@ -8,6 +8,11 @@
       "@contextual": "bolean",
       "@display-view-all": "boolean"
     },
+    "common-leaders-directory-page": {
+      "template": "./directory-page.marko",
+      "@expanded": "boolean",
+      "@display-view-all": "boolean"
+    },
     "common-leaders-home-page": {
       "template": "./home-page.marko",
       "@expanded": "boolean",

--- a/packages/minexpo/components/nodes/company.marko
+++ b/packages/minexpo/components/nodes/company.marko
@@ -76,7 +76,7 @@ $ const imageLink = primaryImage.src ? { href: content.siteContext.path, attrs: 
       </if>
       <if(content.website)>
         <marko-web-link href=content.website>
-          Website
+          website
         </marko-web-link>
       </if>
       <!-- <if(content.address1)>

--- a/packages/minexpo/components/nodes/company.marko
+++ b/packages/minexpo/components/nodes/company.marko
@@ -75,7 +75,9 @@ $ const imageLink = primaryImage.src ? { href: content.siteContext.path, attrs: 
         </marko-web-block>
       </if>
       <if(content.website)>
-        <marko-web-content-website obj=content link={ href: content.website, title: content.website } />
+        <marko-web-link href=content.website>
+          Website
+        </marko-web-link>
       </if>
       <!-- <if(content.address1)>
         <div class=`${blockName}__content-company-address`>

--- a/packages/minexpo/scss/index.scss
+++ b/packages/minexpo/scss/index.scss
@@ -65,6 +65,9 @@
   &__items {
     &--secondary {
       flex-grow: 1;
+      flex-direction: row-reverse;
+      margin-bottom: auto;
+      padding-right: map-get($spacers, block);;
     }
   }
 }

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -102,7 +102,7 @@ $ const perPage = 20;
                 <div class="mb-block">
                   <marko-web-gam-display-ad id="gpt-ad-rail1" />
                 </div>
-                <div class="directory-filters">
+                <div class="directory-filters mb-block">
                   <h3 class="directory-filters__title mb-block">
                     Filters:
                   </h3>
@@ -223,7 +223,9 @@ $ const perPage = 20;
                   </div>
 
                 </div>
-
+                <div class="mb-block">
+                  <common-leaders-directory-page expanded=false />
+                </div>
               </div>
               <div class="col-lg-8 mb-block">
                 <minexpo-content-search-query|{ nodes, totalCount, facets }|

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -260,6 +260,7 @@ $ const perPage = 20;
                           <@slot|{ node }|>
                             <minexpo-company-node
                               with-section=false
+                              with-teaser=false
                               node=node
                               modifiers=["content-list"]
                             >

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -99,9 +99,6 @@ $ const perPage = 20;
             $ const sectionIds = getChildIds(section, [section.id]);
             <div class="row">
               <div class="col-lg-4">
-                <div class="mb-block">
-                  <marko-web-gam-display-ad id="gpt-ad-rail1" />
-                </div>
                 <div class="directory-filters mb-block">
                   <h3 class="directory-filters__title mb-block">
                     Filters:
@@ -222,6 +219,9 @@ $ const perPage = 20;
                     </div>
                   </div>
 
+                </div>
+                <div class="mb-block">
+                  <marko-web-gam-display-ad id="gpt-ad-rail1" />
                 </div>
                 <div class="mb-block">
                   <common-leaders-directory-page expanded=false />

--- a/sites/minexpo.com/config/navigation.js
+++ b/sites/minexpo.com/config/navigation.js
@@ -1,14 +1,15 @@
 const primary = [
   { href: '/directory', label: 'Exhibitor Directory' },
   { href: '/exhibitor-news', label: 'Exhibitor News' },
-  { href: 'https://www.MINExpo.com', label: 'MINExpo.com' },
+  { href: '/leaders', label: 'Featured Exhibitors' },
   // eslint-disable-next-line no-script-url
   { href: 'javascript:void(0)', label: 'Exhibit Hall Map' },
+  // eslint-disable-next-line no-script-url
+  { href: 'javascript:void(0)', label: 'Export Directory' },
 ];
 
 const secondary = [
-  // eslint-disable-next-line no-script-url
-  { href: 'javascript:void(0)', label: 'Export Directory' },
+  { href: 'https://www.MINExpo.com', label: 'MINExpo.com' },
 ];
 
 const resources = [];

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -52,8 +52,8 @@ $theme-site-header-breakpoints: (
 
   @media (min-width: map-get($theme-site-header-breakpoints, small-text-primary)) {
     background: #dde5f2;
-    background: url("https://img.hub.heart.org/files/base/ascend/minexpo/image/static/minexpo-bg.jpg");
-    background: url("https://img.hub.heart.org/files/base/ascend/minexpo/image/static/minexpo-bg.png") no-repeat 50% 120px, linear-gradient(180deg, #dde5f2 517px, #dfe3e2 631px, #c2ccd6 664px, #c7c6a7 680px, #8791c4 758px, #59659d 810px, #59659d 900px);
+    background: url("https://img.hub.heart.org/files/base/ascend/minexpo/image/static/minexpo-bg-nofade.jpg") no-repeat 50% 120px, #59659d;
+    // background: url("https://img.hub.heart.org/files/base/ascend/minexpo/image/static/minexpo-bg-nofade.jpg") no-repeat 50% 120px, linear-gradient(180deg, #dde5f2 517px, #dfe3e2 631px, #c2ccd6 664px, #c7c6a7 680px, #8791c4 758px, #59659d 810px, #59659d 900px);
     .page {
       background-color: transparent;
     }

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -46,7 +46,7 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@ascend-media/package-minexpo/scss/index";
 
 .body-wrapper {
-  display: block;
+  display: flex;
   flex-direction: column;
   height: auto;
 


### PR DESCRIPTION
  - Add Featured Exhibitors box to left rail of directory pages
  - Move 300x250 between Filters & Featured Exhibitors in left rail
  - Update background to only have the image and solid color, remove blur
  - Align secondary nav with hamburger menu and items align right
  - Move items around in the secondary and primary nav
  - Fix display issue of leaders modal after adding background support
  - Update company node display for directory listings
  -- Hide teaser
  -- Display website instead of actual URL

![MINExpoDirectory](https://user-images.githubusercontent.com/3845869/113721897-87693c80-96b5-11eb-8339-833e7dd7fbc3.jpeg)
<img width="756" alt="Screen Shot 2021-04-06 at 8 52 25 AM" src="https://user-images.githubusercontent.com/3845869/113721913-8a642d00-96b5-11eb-919f-56a16c735b8a.png">
