### PR TITLE
MINExpo Company Page updates

### DIFF
--- a/packages/minexpo/components/blocks/company-product-categories.marko
+++ b/packages/minexpo/components/blocks/company-product-categories.marko
@@ -1,0 +1,24 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { getChildSectionIds } from "../../utils/get-child-section-ids";
+import categorySectionsFragment from "../../graphql/fragments/category-sections"
+
+$ const alias = defaultValue(input.alias, 'directory');
+$ const schedules = defaultValue(input.schedules, []);
+
+<marko-web-query|{ node }|
+  name="website-section"
+  params={ alias, queryFragment: categorySectionsFragment }
+>
+  $ const ids = getChildSectionIds(node, []);
+  $ const productCategorySchedules = schedules.filter(schedule => ids.includes(schedule.section.id)).map(schedule => schedule.section.name ).sort();
+    <marko-web-node-list collapsible=false class="mt-block" modifiers=["product-categories"]>
+      <@header>
+        Product Categories
+      </@header>
+      <@body>
+        <for|category| of=productCategorySchedules>
+          <marko-web-block class="node-list__node">${category}</marko-web-block>
+        </for>
+      </@body>
+    </marko-web-node-list>
+</marko-web-query>

--- a/packages/minexpo/components/blocks/marko.json
+++ b/packages/minexpo/components/blocks/marko.json
@@ -22,6 +22,11 @@
       "default-value": false
     }
   },
+  "<minexpo-company-product-categories-block>": {
+    "template": "./company-product-categories.marko",
+    "@alias": "array",
+    "@schedules": "array"
+  },
   "<minexpo-content-load-more-block>": {
     "template": "./content-load-more.marko",
     "<native-x>": {

--- a/packages/minexpo/components/elements/company-contact-details.marko
+++ b/packages/minexpo/components/elements/company-contact-details.marko
@@ -1,0 +1,93 @@
+import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+
+$ const content = getAsObject(input, "obj");
+$ const showEmail = input.showEmail != null ? input.showEmail : true;
+
+$ const addressFields = ["address1", "address2", "cityStateZip", "country"];
+$ const showAddress = addressFields.some(k => content[k]);
+
+$ const phoneFields = ["phone", "fax", "mobile", "tollfree"];
+$ const showPhones = phoneFields.some(k => content[k]);
+
+$ const socialLinks = getAsArray(content, "socialLinks");
+$ const showSocial = socialLinks.length;
+
+$ const fields = ["title", "website"];
+$ if (showEmail) fields.push("publicEmail");
+$ const showFields = fields.some(k => content[k]);
+
+$ const websiteLinkAttrs = getAsObject(input, "websiteLinkAttrs");
+$ const socialLinkAttrs = getAsObject(input, "socialLinkAttrs");
+
+<default-theme-page-contact-details|{ blockName }|
+  tag=input.tag
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  <if(showAddress)>
+    <default-theme-content-contact-details-section block-name=blockName>
+      <address class=`${blockName}__address`>
+        <marko-web-content-address1 block-name=blockName obj=content />
+        <marko-web-content-address2 block-name=blockName obj=content />
+        <marko-web-content-city-state-zip block-name=blockName obj=content />
+        <marko-web-content-country block-name=blockName obj=content />
+      </address>
+    </default-theme-content-contact-details-section>
+  </if>
+
+  <if(showFields)>
+    <default-theme-content-contact-details-section block-name=blockName>
+      <marko-web-content-title block-name=blockName obj=content />
+      <if(showEmail)>
+        <marko-web-content-public-email block-name=blockName obj=content link=true/>
+      </if>
+      <div class="col-sm-4 px-0">
+        <common-leaders-company-website-link company=content />
+      </div>
+    </default-theme-content-contact-details-section>
+  </if>
+
+  <if(showSocial)>
+    <default-theme-content-contact-details-section block-name=blockName modifiers=["social-links"]>
+      <for|item| of=socialLinks>
+        <default-theme-social-icon-link
+          label=item.label
+          provider=item.provider
+          href=item.url
+          modifiers=["dark", "lg"]
+          attrs=socialLinkAttrs
+        />
+      </for>
+    </default-theme-content-contact-details-section>
+  </if>
+
+  <if(showPhones)>
+    <default-theme-content-contact-details-section block-name=blockName>
+      <if(content.phone)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Phone:</span>
+          <marko-web-content-phone block-name=blockName obj=content />
+        </div>
+      </if>
+      <if(content.mobile)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Mobile:</span>
+          <marko-web-content-mobile block-name=blockName obj=content />
+        </div>
+      </if>
+      <if(content.tollfree)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Toll Free:</span>
+          <marko-web-content-tollfree block-name=blockName obj=content />
+        </div>
+      </if>
+      <if(content.fax)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Fax:</span>
+          <marko-web-content-fax block-name=blockName obj=content />
+        </div>
+      </if>
+    </default-theme-content-contact-details-section>
+  </if>
+</default-theme-page-contact-details>

--- a/packages/minexpo/components/elements/marko.json
+++ b/packages/minexpo/components/elements/marko.json
@@ -3,6 +3,23 @@
     "minexpo-gam-content-targeting": {
       "template": "./gam-content-targeting.marko",
       "@obj": "object"
+    },
+    "minexpo-company-contact-details": {
+      "template": "./company-contact-details.marko",
+      "@obj": "object",
+      "@show-email": {
+        "type": "boolean",
+        "default-value": true
+      },
+      "@tag": {
+        "type": "string",
+        "default-value": "div"
+      },
+      "@class": "string",
+      "@modifiers": "array",
+      "@attrs": "object",
+      "@website-link-attrs": "object",
+      "@social-link-attrs": "object"
     }
   }
 }

--- a/packages/minexpo/components/page-wrappers/content/leader.marko
+++ b/packages/minexpo/components/page-wrappers/content/leader.marko
@@ -45,8 +45,8 @@ $ const { id, type, content } = input;
       <@body>
         <label class="content-section-header">About ${content.name}</label>
         <marko-web-content-teaser tag="p" obj=content />
-        <label class="content-section-header">Product Summary</label>
-        <marko-web-obj-text tag="p" obj=content field="productSummary" type="content" html=true />
+        <!-- <label class="content-section-header">Product Summary</label>
+        <marko-web-obj-text tag="p" obj=content field="productSummary" type="content" html=true /> -->
       </@body>
     </marko-web-node-list>
 
@@ -62,15 +62,16 @@ $ const { id, type, content } = input;
           </marko-web-block>
         </if>
 
-        <label class="content-section-header content-section-header--border">At-a-glance</label>
-        <common-company-details company=content />
+        <!-- <label class="content-section-header content-section-header--border">At-a-glance</label>
+        <common-company-details company=content /> -->
 
         <label class="content-section-header content-section-header--border">Contact</label>
         $ const { socialLinks, ...contentSansSocial } = content;
-        <default-theme-content-contact-details obj=contentSansSocial />
+        <minexpo-company-contact-details obj=contentSansSocial />
+        <!-- <default-theme-content-contact-details obj=contentSansSocial /> -->
 
-        <label class="content-section-header content-section-header--border">More info on ${content.name}</label>
-        <marko-web-content-body obj=content />
+        <!-- <label class="content-section-header content-section-header--border">More info on ${content.name}</label>
+        <marko-web-content-body obj=content /> -->
       </@body>
     </marko-web-node-list>
 

--- a/packages/minexpo/components/page-wrappers/content/leader.marko
+++ b/packages/minexpo/components/page-wrappers/content/leader.marko
@@ -161,7 +161,7 @@ $ const { id, type, content } = input;
       </@body>
     </marko-web-node-list> -->
     <div class="mt-block">
-      <shared-directory-categories-block aliases=[] title="Search Product Categories" description="Select a category below:" />
+      <minexpo-company-product-categories-block content-id=id schedules=content.websiteSchedules />
     </div>
 
     $ const contacts = getAsArray(content, "contacts.edges").map(({ node }) => node);

--- a/packages/minexpo/graphql/fragments/content-company.js
+++ b/packages/minexpo/graphql/fragments/content-company.js
@@ -34,6 +34,14 @@ fragment WebsiteContentCompanyFragment on Content {
       url
     }
 
+    websiteSchedules {
+      section {
+        id
+        name
+        fullName
+      }
+    }
+
     # kv data
     yearsInOperation
     numberOfEmployees

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -6,6 +6,8 @@ import queryFragment from "../../graphql/fragments/content-list";
 import { retrieveSections } from "../../utils/retrieve-sections";
 import categorySectionsFragment from "../../graphql/fragments/category-sections"
 import { buildContentQuery } from "../../components/search/queries";
+import { getChildSectionIds } from "../../utils/get-child-section-ids";
+
 
 $ const { $algolia, apollo, GAM, pagination: p, req } = out.global;
 $ const contentType = defaultValue(req.query.type, 'Company');
@@ -85,18 +87,7 @@ $ const perPage = 20;
             name="website-section"
             params={ alias: section.alias, queryFragment: categorySectionsFragment }
           >
-
-            $ const getChildIds = (section, ids) => {
-              ids.push(...getAsArray(sectionWithChildren, "children.edges").map(({ node }) => node.id));
-              const children = getAsArray(sectionWithChildren, "children.edges").map(({ node }) => node);
-
-              children.forEach((child) => {
-                ids.push(...getAsArray(child, "children.edges").map(({ node }) => node.id));
-              })
-              return ids;
-            };
-
-            $ const sectionIds = getChildIds(section, [section.id]);
+            $ const sectionIds = getChildSectionIds(sectionWithChildren, [sectionWithChildren.id]);
             <div class="row">
               <div class="col-lg-4">
                 <div class="mb-block">

--- a/packages/minexpo/utils/get-child-section-ids.js
+++ b/packages/minexpo/utils/get-child-section-ids.js
@@ -1,0 +1,14 @@
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+
+
+const getChildSectionIds = (section, ids) => {
+  const children = getAsArray(section, 'children.edges').map(({ node }) => node);
+
+  children.forEach((child) => {
+    ids.push(child.id);
+    getChildSectionIds(child, ids);
+  });
+  return ids;
+};
+
+module.exports = { getChildSectionIds };


### PR DESCRIPTION
 - Hide Product Summary under Company Overview
 - Hide At-A-Glance under Company Details
 - Do not display the url. We only want the url to be linked in the “visit site” button under Company Details.
 - Hide “More Info On..” under Company Details
 - List company product categories where the “Search Product Categories” box is currently
 -- Alpha list of directory child section a company is scheduled to

![MINExpoCompanyPage](https://user-images.githubusercontent.com/3845869/113759971-53087700-96db-11eb-848f-57c748cbd9fc.jpeg)
