### PR TITLE
Make Featured Exhibitors block have flyout on directory ages

### DIFF
--- a/packages/common/components/leaders/directory-page.marko
+++ b/packages/common/components/leaders/directory-page.marko
@@ -19,6 +19,7 @@ $ const displayViewAll = defaultValue(input.displayViewAll, true);
   displayCallout: false,
   calloutValue: site.get('leaders.title'),
   mediaQueries: [
+    { prop: "open", value: "right", query: "(min-width: 1490px)" },
     { prop: "columns", value: 1, query: "(min-width: 700px)" },
   ],
 }/>


### PR DESCRIPTION
<img width="1213" alt="Screen Shot 2021-04-08 at 1 38 04 PM" src="https://user-images.githubusercontent.com/3845869/114079391-c3480180-986f-11eb-9063-30182629b7b5.png">
