### PR TITLE
AUA Homepage updates

### DIFF
--- a/packages/global/components/nodes/content-list.marko
+++ b/packages/global/components/nodes/content-list.marko
@@ -1,6 +1,10 @@
 import { getAsObject, getAsArray, get } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
+$ const { site } = out.global;
+
+$ const sponsoredText = defaultValue(site.get('sponsoredText'), 'Sponsored Content');
+
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
@@ -16,11 +20,14 @@ $ const isEbook = content.type === "ebook";
 $ const isPromotion = content.type === "promotion";
 $ const isEvent = ["event", "webinar"].includes(content.type);
 $ const isUpcoming = content.startDate > Date.now();
+$ const sponsored = getAsArray(content, "labels").includes("Sponsored");
 
 $ let aspectRatio = get(input, "image.ar", "1:1");
 $ if (isEbook) aspectRatio = "3:4";
 
 $ const { linkAttrs } = input;
+$ const modifiers = [`section-${primarySection.alias}`, ...getAsArray(input, "modifiers")];
+$ if (sponsored) modifiers.push('sponsored');
 
 <marko-web-node
   type=`${content.type}-content`
@@ -29,7 +36,7 @@ $ const { linkAttrs } = input;
   flush=defaultValue(input.flush, true)
   full-height=defaultValue(input.fullHeight, false)
   attrs=input.attrs
-  modifiers=[`section-${primarySection.alias}`, ...getAsArray(input, "modifiers")]
+  modifiers=modifiers
 >
   <if(defaultValue(input.displayImage, true))>
     <@image
@@ -51,8 +58,8 @@ $ const { linkAttrs } = input;
       <@header>
         <@left|{ blockName }|>
           <if(withSection)>
-            <if(getAsArray(content, "labels").includes("Sponsored"))>
-              <marko-web-website-section-name obj={ name: "Supported Content" } link=false />
+            <if(sponsored)>
+              <marko-web-website-section-name obj={ name: sponsoredText } link=false />
             </if>
             <else>
               <marko-web-website-section-name obj=primarySection link=true />

--- a/packages/global/graphql/fragments/section-list-content.js
+++ b/packages/global/graphql/fragments/section-list-content.js
@@ -1,0 +1,21 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment WebsiteSectionListContentFragment on Content {
+  id
+  type
+  shortName
+  teaser(input: { useFallback: false, maxLength: null })
+  siteContext {
+    path
+  }
+  primaryImage {
+    id
+    src
+    alt
+    isLogo
+  }
+}
+
+`;

--- a/packages/global/graphql/fragments/section-list-section.js
+++ b/packages/global/graphql/fragments/section-list-section.js
@@ -1,0 +1,12 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment WebsiteSectionListSectionFragment on WebsiteSection {
+  id
+  name
+  fullName
+  canonicalPath
+}
+
+`;

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -194,12 +194,20 @@ $ const displayCompanyHeader = (content) => {
 
             <aside class="col-lg-4 page-rail">
               <if(displayInquiry(content))>
-                <marko-web-node-list collapsible=false modifiers=["sticky-top"]>
+                <marko-web-gam-define-display-ad
+                  ...GAM.getAdUnit({ name: 'rail1', aliases })
+                  class="mb-block"
+                />
+                <marko-web-node-list collapsible=false>
                   <@header>Request More Information</@header>
                   <@body>
                     <marko-web-inquiry-form content=content with-header=false modifiers=["right-rail"] />
                   </@body>
                 </marko-web-node-list>
+                <marko-web-gam-define-display-ad
+                ...GAM.getAdUnit({ name: 'rail2', aliases })
+                  class="mb-block"
+                />
               </if>
               <else>
                 <global-global-right-rail-block aliases=aliases no-shadow=true />

--- a/sites/auadailynews.org/config/site.js
+++ b/sites/auadailynews.org/config/site.js
@@ -7,6 +7,7 @@ module.exports = {
   navigation,
   gam,
   company: 'Ascend Media',
+  sponsoredText: 'Paid Advertising Content',
   socialMediaLinks: [
     { provider: 'twitter', href: 'https://twitter.com/au_antigua?lang=en', target: '_blank' },
     { provider: 'facebook', href: 'https://www.facebook.com/AmerUrological/', target: '_blank' },

--- a/sites/auadailynews.org/server/styles/index.scss
+++ b/sites/auadailynews.org/server/styles/index.scss
@@ -16,22 +16,11 @@ $theme-site-navbar-secondary-type: light;
 
 @import "../../node_modules/@ascend-media/package-global/scss/theme";
 
-// .body-wrapper {
-//   display: block;
-//   flex-direction: column;
-//   height: auto;
-
-//   @media (min-width: map-get($theme-site-header-breakpoints, small-text-primary)) {
-//     background: url("https://img.ascendmedia.com/files/base/ascend/hearthub/image/static/imex-background.jpg?w=1850") no-repeat 50% 85px;
-
-//     .page {
-//       background-color: transparent;
-//     }
-//   }
-// }
-
-// .site-navbar {
-//   &--secondary {
-//     background: linear-gradient(0deg, #082138 0%, $primary 100%);
-//   }
-// }
+.node {
+  &__footer-left a {
+    color: $secondary;
+  }
+  &__footer-right {
+    white-space: nowrap;
+  }
+}

--- a/sites/auadailynews.org/server/templates/index.marko
+++ b/sites/auadailynews.org/server/templates/index.marko
@@ -30,7 +30,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 9,
+    limit: 8,
     requiresImage: true,
     queryFragment
   },
@@ -69,17 +69,29 @@ $ const promise = websiteSectionContentLoader(apollo, {
       </@above-page>
       <@page>
         <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 5) cols=3 ad-index=1 ad-name="rail1" ad-modifiers=["paid"]>
-          <@native-x index=3 name="default" section-name="Supported Content" />
-        </global-content-card-deck-flow>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 7) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
+        <div class="row">
+          <div class="col-lg-8">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 4) />
+          </div>
+          <div class="col-lg-4">
+            <global-standard-section-list-block
+              section-alias="industry-resources"
+              inner-justified=false
+              query-params={ limit: 2, requiresImage: false }
+              display-image=false
+              modifiers=["sponsored"]
+            />
+          </div>
+        </div>
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(4, 6) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-4 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 9) cols=2 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=1 />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />


### PR DESCRIPTION
 - Add additional sponsored content support to content card
 - add missing fragments
 - add ads around sponsored content right rail RMI
 - Add sponsored content label to config
 - update homepage layout

![AUAhomepage](https://user-images.githubusercontent.com/3845869/116601508-346b5980-a8f0-11eb-867e-60f46a8362ae.jpeg)
