### PR TITLE
Allow documents in More From This Company section.

### DIFF
--- a/packages/minexpo/templates/content/company.marko
+++ b/packages/minexpo/templates/content/company.marko
@@ -19,7 +19,7 @@ $ const { id, type, pageNode } = data;
     </@page>
     <@below-page>
 
-        $ const includeContentTypes = ["Article", "Blog", "Product", "News", "PressRelease", "Webinar", "Whitepaper", "Video"];
+        $ const includeContentTypes = ["Article", "Blog", "Product", "News", "PressRelease", "Webinar", "Whitepaper", "Video", "Document"];
 
         <marko-web-load-more
           header=`More from ${content.name}`


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-07-01 at 8 12 43 AM" src="https://user-images.githubusercontent.com/46794001/124130218-264ace00-da44-11eb-883a-2876f1ff7b34.png">


Item in middle of screenshot is a document content type.