### PR TITLE
MINExpo tweaks

### DIFF
--- a/packages/minexpo/components/blocks/company-export-categories.marko
+++ b/packages/minexpo/components/blocks/company-export-categories.marko
@@ -1,0 +1,27 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { getChildSectionIds } from "../../utils/get-child-section-ids";
+import categorySectionsFragment from "../../graphql/fragments/category-sections"
+
+$ const alias = defaultValue(input.alias, 'export-directory');
+$ const schedules = defaultValue(input.schedules, []);
+
+<marko-web-query|{ node }|
+  name="website-section"
+  params={ alias, queryFragment: categorySectionsFragment }
+>
+  $ const ids = getChildSectionIds(node, []);
+  $ const productCategorySchedules = schedules.filter(schedule => ids.includes(schedule.section.id)).map(schedule => schedule.section.name ).sort();
+
+    <marko-web-node-list collapsible=false class="mt-block" modifiers=["product-categories"]>
+      <@header>
+        Export Categories
+      </@header>
+      <@body>
+        <default-theme-card-deck-flow cols=2 nodes=productCategorySchedules>
+          <@slot|{ node, index }|>
+            <marko-web-block class="node-list__node">${node}</marko-web-block>
+          </@slot>
+        </default-theme-card-deck-flow>
+      </@body>
+    </marko-web-node-list>
+</marko-web-query>

--- a/packages/minexpo/components/blocks/company-export-categories.marko
+++ b/packages/minexpo/components/blocks/company-export-categories.marko
@@ -11,17 +11,18 @@ $ const schedules = defaultValue(input.schedules, []);
 >
   $ const ids = getChildSectionIds(node, []);
   $ const productCategorySchedules = schedules.filter(schedule => ids.includes(schedule.section.id)).map(schedule => schedule.section.name ).sort();
-
-    <marko-web-node-list collapsible=false class="mt-block" modifiers=["product-categories"]>
-      <@header>
-        Export Categories
-      </@header>
-      <@body>
-        <default-theme-card-deck-flow cols=2 nodes=productCategorySchedules>
-          <@slot|{ node, index }|>
-            <marko-web-block class="node-list__node">${node}</marko-web-block>
-          </@slot>
-        </default-theme-card-deck-flow>
-      </@body>
-    </marko-web-node-list>
+    <if(productCategorySchedules.length)>
+      <marko-web-node-list collapsible=false class="mt-block" modifiers=["product-categories"]>
+        <@header>
+          Export Categories
+        </@header>
+        <@body>
+          <default-theme-card-deck-flow cols=2 nodes=productCategorySchedules>
+            <@slot|{ node, index }|>
+              <marko-web-block class="node-list__node">${node}</marko-web-block>
+            </@slot>
+          </default-theme-card-deck-flow>
+        </@body>
+      </marko-web-node-list>
+    </if>
 </marko-web-query>

--- a/packages/minexpo/components/blocks/marko.json
+++ b/packages/minexpo/components/blocks/marko.json
@@ -31,6 +31,11 @@
     "@alias": "array",
     "@schedules": "array"
   },
+  "<minexpo-company-export-categories-block>": {
+    "template": "./company-export-categories.marko",
+    "@alias": "array",
+    "@schedules": "array"
+  },
   "<minexpo-content-load-more-block>": {
     "template": "./content-load-more.marko",
     "<native-x>": {

--- a/packages/minexpo/components/nodes/company.marko
+++ b/packages/minexpo/components/nodes/company.marko
@@ -75,7 +75,7 @@ $ const imageLink = primaryImage.src ? { href: content.siteContext.path, attrs: 
         </marko-web-block>
       </if>
       <if(content.website)>
-        <marko-web-link href=content.website>
+        <marko-web-link href=content.website target="_blank" >
           website
         </marko-web-link>
       </if>

--- a/packages/minexpo/components/page-wrappers/content/leader.marko
+++ b/packages/minexpo/components/page-wrappers/content/leader.marko
@@ -65,6 +65,77 @@ $ const { id, type, content } = input;
       </@body>
     </marko-web-node-list>
 
+    <marko-web-node-list collapsible=false class="mt-block">
+      <@header>
+        Export Details
+      </@header>
+      <@body>
+        $ const businessContacts = getAsArray(content, "businessContacts.edges").map(({ node }) => node);
+        <if(businessContacts.length)>
+          <label class="content-section-header content-section-header--border">Public Contact(s)</label>
+          <for|contact| of=businessContacts>
+            <marko-web-block>
+              ${contact.name}
+              <if(contact.title)>
+                (${contact.title})
+              </if>
+              <if(contact.publicEmail)>
+                :
+                <marko-web-link href=`mailto:${contact.publicEmail}` title=`Email ${contact.name}`>
+                  ${contact.publicEmail}
+                </marko-web-link>
+              </if>
+            </marko-web-block>
+          </for>
+        </if>
+        $ const marketingContacts = getAsArray(content, "marketingContacts.edges").map(({ node }) => node);
+        <if(marketingContacts.length)>
+          <label class="content-section-header content-section-header--border">Marketing Contact(s)</label>
+          <for|contact| of=marketingContacts>
+            <marko-web-block>
+              ${contact.name}
+              <if(contact.title)>
+                (${contact.title})
+              </if>
+              <if(contact.publicEmail)>
+                :
+                <marko-web-link href=`mailto:${contact.publicEmail}` title=`Email ${contact.name}`>
+                  ${contact.publicEmail}
+                </marko-web-link>
+              </if>
+            </marko-web-block>
+          </for>
+        </if>
+        <if(content.exportInterest)>
+          <label class="content-section-header content-section-header--border">Export Interest</label>
+          <marko-web-block>
+            ${content.exportInterest}
+          </marko-web-block>
+        </if>
+        <if(content.exportMarkets)>
+          <label class="content-section-header content-section-header--border">Currently exports to the following markets</label>
+          <marko-web-block>
+            ${content.exportMarkets}
+          </marko-web-block>
+        </if>
+        <if(content.internationalBusinessInterest)>
+          <label class="content-section-header content-section-header--border">International business in which your company is interested in</label>
+          <marko-web-block>
+            ${content.internationalBusinessInterest}
+          </marko-web-block>
+        </if>
+        <if(content.marketingInterest)>
+          <label class="content-section-header content-section-header--border">We are most interested in marketing our products/services to</label>
+          <marko-web-block>
+            ${content.marketingInterest}
+          </marko-web-block>
+        </if>
+
+      </@body>
+    </marko-web-node-list>
+
+    <minexpo-company-export-categories-block schedules=content.websiteSchedules />
+
     <marko-web-query|{ nodes }|
       name="all-company-content"
       params={

--- a/packages/minexpo/components/page-wrappers/content/leader.marko
+++ b/packages/minexpo/components/page-wrappers/content/leader.marko
@@ -3,6 +3,16 @@ import queryFragment from "../../../graphql/fragments/content-list";
 
 $ const { site } = out.global;
 $ const { id, type, content } = input;
+$ const businessContacts = getAsArray(content, "businessContacts.edges").map(({ node }) => node);
+$ const marketingContacts = getAsArray(content, "marketingContacts.edges").map(({ node }) => node);
+$ const displayExportDetails = (
+  businessContacts.length ||
+  marketingContacts.length ||
+  content.exportInterest ||
+  content.exportMarkets ||
+  content.internationalBusinessInterest ||
+  content.marketingInterest
+);
 
 <marko-web-page-wrapper>
   <@section>
@@ -64,75 +74,74 @@ $ const { id, type, content } = input;
         <minexpo-company-contact-details obj=contentSansSocial />
       </@body>
     </marko-web-node-list>
-
-    <marko-web-node-list collapsible=false class="mt-block">
-      <@header>
-        Export Details
-      </@header>
-      <@body>
-        $ const businessContacts = getAsArray(content, "businessContacts.edges").map(({ node }) => node);
-        <if(businessContacts.length)>
-          <label class="content-section-header content-section-header--border">Public Contact(s)</label>
-          <for|contact| of=businessContacts>
+    <if(displayExportDetails)>
+      <marko-web-node-list collapsible=false class="mt-block">
+        <@header>
+          Export Details
+        </@header>
+        <@body>
+          <if(businessContacts.length)>
+            <label class="content-section-header content-section-header--border">Public Contact(s)</label>
+            <for|contact| of=businessContacts>
+              <marko-web-block>
+                ${contact.name}
+                <if(contact.title)>
+                  (${contact.title})
+                </if>
+                <if(contact.publicEmail)>
+                  :
+                  <marko-web-link href=`mailto:${contact.publicEmail}` title=`Email ${contact.name}`>
+                    ${contact.publicEmail}
+                  </marko-web-link>
+                </if>
+              </marko-web-block>
+            </for>
+          </if>
+          <if(marketingContacts.length)>
+            <label class="content-section-header content-section-header--border">Marketing Contact(s)</label>
+            <for|contact| of=marketingContacts>
+              <marko-web-block>
+                ${contact.name}
+                <if(contact.title)>
+                  (${contact.title})
+                </if>
+                <if(contact.publicEmail)>
+                  :
+                  <marko-web-link href=`mailto:${contact.publicEmail}` title=`Email ${contact.name}`>
+                    ${contact.publicEmail}
+                  </marko-web-link>
+                </if>
+              </marko-web-block>
+            </for>
+          </if>
+          <if(content.exportInterest)>
+            <label class="content-section-header content-section-header--border">Export Interest</label>
             <marko-web-block>
-              ${contact.name}
-              <if(contact.title)>
-                (${contact.title})
-              </if>
-              <if(contact.publicEmail)>
-                :
-                <marko-web-link href=`mailto:${contact.publicEmail}` title=`Email ${contact.name}`>
-                  ${contact.publicEmail}
-                </marko-web-link>
-              </if>
+              ${content.exportInterest}
             </marko-web-block>
-          </for>
-        </if>
-        $ const marketingContacts = getAsArray(content, "marketingContacts.edges").map(({ node }) => node);
-        <if(marketingContacts.length)>
-          <label class="content-section-header content-section-header--border">Marketing Contact(s)</label>
-          <for|contact| of=marketingContacts>
+          </if>
+          <if(content.exportMarkets)>
+            <label class="content-section-header content-section-header--border">Currently exports to the following markets</label>
             <marko-web-block>
-              ${contact.name}
-              <if(contact.title)>
-                (${contact.title})
-              </if>
-              <if(contact.publicEmail)>
-                :
-                <marko-web-link href=`mailto:${contact.publicEmail}` title=`Email ${contact.name}`>
-                  ${contact.publicEmail}
-                </marko-web-link>
-              </if>
+              ${content.exportMarkets}
             </marko-web-block>
-          </for>
-        </if>
-        <if(content.exportInterest)>
-          <label class="content-section-header content-section-header--border">Export Interest</label>
-          <marko-web-block>
-            ${content.exportInterest}
-          </marko-web-block>
-        </if>
-        <if(content.exportMarkets)>
-          <label class="content-section-header content-section-header--border">Currently exports to the following markets</label>
-          <marko-web-block>
-            ${content.exportMarkets}
-          </marko-web-block>
-        </if>
-        <if(content.internationalBusinessInterest)>
-          <label class="content-section-header content-section-header--border">International business in which your company is interested in</label>
-          <marko-web-block>
-            ${content.internationalBusinessInterest}
-          </marko-web-block>
-        </if>
-        <if(content.marketingInterest)>
-          <label class="content-section-header content-section-header--border">We are most interested in marketing our products/services to</label>
-          <marko-web-block>
-            ${content.marketingInterest}
-          </marko-web-block>
-        </if>
+          </if>
+          <if(content.internationalBusinessInterest)>
+            <label class="content-section-header content-section-header--border">International business in which your company is interested in</label>
+            <marko-web-block>
+              ${content.internationalBusinessInterest}
+            </marko-web-block>
+          </if>
+          <if(content.marketingInterest)>
+            <label class="content-section-header content-section-header--border">We are most interested in marketing our products/services to</label>
+            <marko-web-block>
+              ${content.marketingInterest}
+            </marko-web-block>
+          </if>
 
-      </@body>
-    </marko-web-node-list>
+        </@body>
+      </marko-web-node-list>
+    </if>
 
     <minexpo-company-export-categories-block schedules=content.websiteSchedules />
 

--- a/packages/minexpo/components/site-header.marko
+++ b/packages/minexpo/components/site-header.marko
@@ -28,14 +28,6 @@ $ if (navigation.secondary.length) tertiaryMods.push("no-left-margin");
         srcset=site.getAsArray("logos.navbar.srcset").join(",")
       />
     </default-theme-site-navbar-brand>
-    <marko-web-block tag="div" class="callout2016 text-center">
-      <h2>
-        DEMO SITE<br>
-        <span class="small">
-          Exhibitor data contained herein is from MINExpo 2016
-        </span>
-      </h2>
-    </marko-web-block>
     <default-theme-site-navbar-items
       items=navigation.secondary
       modifiers=["secondary"]

--- a/packages/minexpo/graphql/fragments/content-company.js
+++ b/packages/minexpo/graphql/fragments/content-company.js
@@ -63,9 +63,30 @@ fragment WebsiteContentCompanyFragment on Content {
     }
 
     isLeader: hasWebsiteSchedule(input: { sectionAlias: "leaders" })
+    exportInterest: customAttribute(input: { path: "exportInterest" })
     boothNumber: customAttribute(input: { path: "boothNumber" })
+    exportMarkets: customAttribute(input: { path: "exportMarkets" })
+    marketingInterest: customAttribute(input: { path: "marketingInterest" })
+    internationalBusinessInterest: customAttribute(input: { path: "internationalBusinessInterest" })
+    alphaGroup: customAttribute(input: { path: "alphaGroup" })
+    boothLocation: customAttribute(input: { path: "boothLocation" })
 
-    contacts: publicContacts {
+    businessContacts: publicContacts {
+      edges {
+        node {
+          id
+          name
+          title
+          publicEmail
+          primaryImage {
+            id
+            src(input: { options: { auto: "format", h: 100, w: 100, mask: "ellipse", fit: "facearea", facepad: 3 } })
+          }
+        }
+      }
+    }
+
+    marketingContacts: marketingContacts {
       edges {
         node {
           id

--- a/packages/minexpo/templates/content/index.marko
+++ b/packages/minexpo/templates/content/index.marko
@@ -113,7 +113,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
             </default-theme-page-contents>
 
             <aside class="col-lg-4 page-rail">
-              <shared-inquiry-block content=content />
               <if(displayAds)>
                 <marko-web-gam-display-ad id="gpt-ad-rail1" />
               </if>

--- a/packages/minexpo/templates/website-section/directory.marko
+++ b/packages/minexpo/templates/website-section/directory.marko
@@ -116,7 +116,7 @@ $ const perPage = 20;
                           initially-expanded=(alias !== primaryAlias)
                         />
                       </div>
-                      <div class="mb-block">
+                      <!-- <div class="mb-block">
                         <div class="content-type-facets">
                           <h3 class="content-type-facets__title">
                             Type
@@ -160,7 +160,7 @@ $ const perPage = 20;
                             </for>
                           </div>
                         </div>
-                      </div>
+                      </div> -->
                       <if('Company' === contentType)>
                         <div class="mb-block">
                           <minexpo-country-facets|{ countries }|


### PR DESCRIPTION
 - Remove 2016 DEMO Callout
 - Remove RMI
 - Hide Type filter on /directory & /export-directory
 - Conditionally display Export Details Custom Attributes when present
 - Add target _blank to website link on list of companies displaying within the directory landing pages

@todo Might have to adjust block title background colors to account for them matching the background color.  Waiting on group feedback.

<img width="1179" alt="Screen Shot 2021-07-21 at 9 02 20 AM" src="https://user-images.githubusercontent.com/3845869/126517374-69aa41ca-0902-4b92-bc8e-a161739822ef.png">
<img width="1104" alt="Screen Shot 2021-07-21 at 10 31 22 AM" src="https://user-images.githubusercontent.com/3845869/126517384-4b5ac72d-67a3-4c5c-8edf-a5031d71b067.png">
<img width="607" alt="Screen Shot 2021-07-21 at 10 38 34 AM" src="https://user-images.githubusercontent.com/3845869/126517659-78363fb5-75a2-4646-a9a0-36c9be7dc2ce.png">


