### PR TITLE
Bring back navigation item for Export Directory.

### DIFF
--- a/sites/minexpo.com/config/navigation.js
+++ b/sites/minexpo.com/config/navigation.js
@@ -3,6 +3,7 @@ const primary = [
   { href: '/exhibitor-news', label: 'Exhibitor News' },
   { href: '/leaders', label: 'Featured Exhibitors' },
   { href: 'https://www.allintheloop.net/App/me/meMINExpo', label: 'Exhibit Hall Floor Plans', target: '_blank' },
+  { href: '/export-directory', label: 'Export Directory' },
 ];
 
 const secondary = [


### PR DESCRIPTION
Git Blame myself: https://github.com/parameter1/ascend-media-websites/pull/185

BEFORE:
<img width="1920" alt="Screen Shot 2021-07-30 at 9 42 31 AM" src="https://user-images.githubusercontent.com/46794001/127669926-7671155b-deeb-4ca6-a814-1d223160d6e7.png">

AFTER:
<img width="1920" alt="Screen Shot 2021-07-30 at 9 42 06 AM" src="https://user-images.githubusercontent.com/46794001/127669948-5650342c-bfb3-40e5-ba91-65bc5a46b5ae.png">
<img width="1920" alt="Screen Shot 2021-07-30 at 9 42 12 AM" src="https://user-images.githubusercontent.com/46794001/127669956-82518b1c-86a8-4a7f-a7e8-f2bf5b1fd910.png">
