### PR TITLE
Add block next to Featured Exhibitors, alter skip.

### DIFF
--- a/sites/minexpo.com/server/templates/website-section/index.marko
+++ b/sites/minexpo.com/server/templates/website-section/index.marko
@@ -64,13 +64,13 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-4 mb-block">
         <marko-web-query|{ nodes }|
           name="website-scheduled-content"
-            params={ limit: 1, skip: 7, requiresImage: true, queryFragment }
-          >
-          <website-content-card-node
-              image-width=340
-              node=nodes[0]
-            />
-          </marko-web-query>
+          params={ limit: 1, skip: 7, requiresImage: true, queryFragment }
+        >
+        <website-content-card-node
+            image-width=340
+            node=nodes[0]
+          />
+        </marko-web-query>
       </div>
     </div>
 

--- a/sites/minexpo.com/server/templates/website-section/index.marko
+++ b/sites/minexpo.com/server/templates/website-section/index.marko
@@ -66,7 +66,7 @@ $ const { id, alias, name, pageNode } = data;
           name="website-scheduled-content"
           params={ limit: 1, skip: 7, requiresImage: true, queryFragment }
         >
-        <website-content-card-node
+          <website-content-card-node
             image-width=340
             node=nodes[0]
           />

--- a/sites/minexpo.com/server/templates/website-section/index.marko
+++ b/sites/minexpo.com/server/templates/website-section/index.marko
@@ -61,6 +61,17 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-8 mb-block">
         <common-leaders-home-page />
       </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+            params={ limit: 1, skip: 7, requiresImage: true, queryFragment }
+          >
+          <website-content-card-node
+              image-width=340
+              node=nodes[0]
+            />
+          </marko-web-query>
+      </div>
     </div>
 
     <div class="row">
@@ -70,7 +81,7 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-8 col-md-6 mb-block">
         <marko-web-query|{ nodes }|
           name="website-scheduled-content"
-          params={ limit: 4, skip: 10, requiresImage: true, queryFragment }
+          params={ limit: 4, skip: 8, requiresImage: true, queryFragment }
         >
         <default-theme-card-deck-flow cols=2 nodes=nodes>
           <@slot|{ node, index }|>
@@ -86,7 +97,7 @@ $ const { id, alias, name, pageNode } = data;
 
     <marko-web-query|{ nodes }|
       name="website-scheduled-content"
-      params={ sectionId: id, limit: 16, skip: 14, requiresImage: true, queryFragment }
+      params={ sectionId: id, limit: 16, skip: 12, requiresImage: true, queryFragment }
     >
       <default-theme-card-deck-flow cols=3 nodes=nodes>
         <@slot|{ node, index }|>
@@ -112,7 +123,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         fragment-name="content-list"
         query-name="website-scheduled-content"
-        query-params={ sectionId: id, limit: 12, skip: 30, requiresImage: true }
+        query-params={ sectionId: id, limit: 12, skip: 28, requiresImage: true }
         max-pages=3
         page-input={ for: "website-section", id }
       />


### PR DESCRIPTION
Previously the queries on this page were skipping content pieces, this is now resolved and there is no content skipped as well as no duplicate content.

BEFORE:

<img width="1919" alt="Screen Shot 2021-07-30 at 12 05 50 PM" src="https://user-images.githubusercontent.com/46794001/127688139-26e7b053-82a4-49a2-ae1e-0dcfb53577b0.png">

AFTER:

<img width="1920" alt="Screen Shot 2021-07-30 at 12 07 28 PM" src="https://user-images.githubusercontent.com/46794001/127688171-5bb49dad-10c0-4f04-8432-fbc883291cbf.png">


