### PR TITLE
Update to display sub-categories.

### DIFF
--- a/packages/common/components/leaders/all.marko
+++ b/packages/common/components/leaders/all.marko
@@ -5,7 +5,7 @@ $ const contextual = defaultValue(input.contextual, true);
 $ const displayViewAll = defaultValue(input.displayViewAll, true);
 
 <marko-web-leaders props={
-  sectionAlias: site.get("leaders.alias"),
+  sectionAlias: 'leaders/2021',
   open: null,
   expanded: true,
   contextual,

--- a/sites/minexpo.com/config/leaders.js
+++ b/sites/minexpo.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Featured Exhibitors',
-  alias: 'directory',
+  alias: 'leaders',
   viewAllText: 'View All Featured Exhibitors &raquo;',
   header: {
     imgSrc: 'https://img.packworld.com/files/base/ascend/minex/image/static/leaders-logo.png?h=90',

--- a/sites/minexpo.com/config/leaders.js
+++ b/sites/minexpo.com/config/leaders.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Featured Exhibitors',
-  alias: 'leaders',
+  alias: 'directory',
   viewAllText: 'View All Featured Exhibitors &raquo;',
   header: {
     imgSrc: 'https://img.packworld.com/files/base/ascend/minex/image/static/leaders-logo.png?h=90',

--- a/sites/minexpo.com/server/styles/index.scss
+++ b/sites/minexpo.com/server/styles/index.scss
@@ -146,13 +146,3 @@ $theme-site-header-breakpoints: (
     }
   }
 }
-
-.leaders-section{
-  &--with-parent{
-    .leaders-section{
-      &__title {
-        display: none;
-      }
-    }
-  }
-}


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2021-08-04 at 12 24 15 PM" src="https://user-images.githubusercontent.com/46794001/128226203-0dd33c9a-4e9a-42ed-b2de-f1aae24b0449.png">

Companies were only correctly scheduled to either /leaders or /directory and not /leaders/2021 hence the alias change.