### PR TITLE
Use the nmaMember field to determine rendering.

### DIFF
--- a/packages/minexpo/components/elements/company-contact-details.marko
+++ b/packages/minexpo/components/elements/company-contact-details.marko
@@ -87,7 +87,8 @@ $ const socialLinkAttrs = getAsObject(input, "socialLinkAttrs");
       </if>
     </default-theme-content-contact-details-section>
   </if>
-  <if(content.nmaOrder)>
+  $ console.log(content)
+  <if(content.nmaMember === "Yes")>
     NMA Member
   </if>
   <div class="col-sm-4 px-0">

--- a/packages/minexpo/components/elements/company-contact-details.marko
+++ b/packages/minexpo/components/elements/company-contact-details.marko
@@ -87,7 +87,6 @@ $ const socialLinkAttrs = getAsObject(input, "socialLinkAttrs");
       </if>
     </default-theme-content-contact-details-section>
   </if>
-  $ console.log(content)
   <if(content.nmaMember === "Yes")>
     NMA Member
   </if>

--- a/packages/minexpo/graphql/fragments/content-company.js
+++ b/packages/minexpo/graphql/fragments/content-company.js
@@ -70,7 +70,7 @@ fragment WebsiteContentCompanyFragment on Content {
     internationalBusinessInterest: customAttribute(input: { path: "internationalBusinessInterest" })
     alphaGroup: customAttribute(input: { path: "alphaGroup" })
     boothLocation: customAttribute(input: { path: "boothLocation" })
-    nmaOrder: customAttribute(input: { path: "nmaOrder" })
+    nmaMember: customAttribute(input: { path: "nmaMember" })
 
     businessContacts: publicContacts {
       edges {


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2021-08-11 at 7 58 33 AM" src="https://user-images.githubusercontent.com/46794001/129033079-0dbb78c7-4a1e-4ac4-825c-2b60ae5f7149.png">
<img width="1792" alt="Screen Shot 2021-08-11 at 7 59 18 AM" src="https://user-images.githubusercontent.com/46794001/129033088-170586bd-f75c-412b-a8d7-f1ef671ce9d9.png">

Gormann has this field set to Yes. Wosley has it set to no.