### PR TITLE
Use GAM for ads on Heart Hub Sites

### DIFF
--- a/packages/shared/components/blocks/global-right-rail.marko
+++ b/packages/shared/components/blocks/global-right-rail.marko
@@ -2,13 +2,23 @@ $ const { GAM } = out.global;
 
 $ const { aliases } = input;
 
-<shared-eposters-mr-block />
+<!--<shared-eposters-mr-block />-->
+<marko-web-gam-define-display-ad
+  ...GAM.getAdUnit({ name: "rail1" })
+  class="mt-block"
+  modifiers=["center"]
+/>
 
 <shared-watch-listen-block />
 
 <shared-early-career-block />
 
-<shared-exhibits-mr-block />
+<!--<shared-exhibits-mr-block />-->
+<marko-web-gam-define-display-ad
+  ...GAM.getAdUnit({ name: "rail2" })
+  class="mt-block"
+  modifiers=["center"]
+/>
 
 <a
   class="twitter-timeline btn btn-primary btn-block"

--- a/packages/shared/components/blocks/qcor-early-career-plenary-buttons.marko
+++ b/packages/shared/components/blocks/qcor-early-career-plenary-buttons.marko
@@ -1,11 +1,11 @@
 import { buildImgixUrl } from "@parameter1/base-cms-image";
 
-$ const src1 = 'https://p1-cms-assets-ascend.imgix.net/files/base/ascend/hearthub/image/static/AHA_QCORHub_FreeSession_Plenary.png';
+$ const src1 = 'https://img.hub.heart.org/files/base/ascend/hearthub/image/static/AHA_QCORHub_FreeSession_Plenary.png';
 $ const imgixUrl1 = buildImgixUrl(src1, { h: 90 });
 $ const srcset1 = [`${buildImgixUrl(imgixUrl1, { h: 90, dpr: 2 })} 2x`];
 $ const href1 = 'https://youtu.be/Qodly1uUg8k';
 
-$ const src2 = 'https://p1-cms-assets-ascend.imgix.net/files/base/ascend/hearthub/image/static/AHA_QCORHub_FreeSession_EarlyCareer.png';
+$ const src2 = 'https://img.hub.heart.org/files/base/ascend/hearthub/image/static/AHA_QCORHub_FreeSession_EarlyCareer.png';
 $ const imgixUrl2 = buildImgixUrl(src2, { h: 90 });
 $ const srcset2 = [`${buildImgixUrl(imgixUrl2, { h: 90, dpr: 2 })} 2x`];
 $ const href2 = 'https://youtu.be/TbG2lieKxeo';

--- a/packages/shared/templates/content/index.marko
+++ b/packages/shared/templates/content/index.marko
@@ -51,9 +51,9 @@ $ const displayCompanyHeader = (content) => {
       </marko-web-page-wrapper>
     </if>
     <else>
-      <shared-leaderboard-block />
+      <!-- <shared-leaderboard-block /> -->
+      <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page", "max-width-790", "center"] />
     </else>
-    <!-- <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page", "max-width-790", "center"] /> -->
 
       $ const aliases = hierarchyAliases(content.primarySection);
       <marko-web-page-wrapper>

--- a/packages/shared/templates/dynamic-page/index.marko
+++ b/packages/shared/templates/dynamic-page/index.marko
@@ -10,12 +10,12 @@ $ const { id, alias, pageNode } = data;
   </@head>
 
   <@page>
-    <shared-leaderboard-block />
-    <!-- <marko-web-gam-define-display-ad
+    <!--<shared-leaderboard-block />-->
+    <marko-web-gam-define-display-ad
       ...GAM.getAdUnit({ name: "lb1" })
       class="mt-block"
       modifiers=["max-width-970", "top-of-page", "center"]
-    /> -->
+    />
 
     <marko-web-resolve-page|{ data: page }| node=pageNode>
       <marko-web-page-wrapper class="mt-block">

--- a/packages/shared/templates/website-section/2020-program.marko
+++ b/packages/shared/templates/website-section/2020-program.marko
@@ -20,12 +20,12 @@ $ const {
     <a class="anchor" name="top" />
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <shared-leaderboard-block />
-      <!-- <marko-web-gam-define-display-ad
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
         ...GAM.getAdUnit({ name: "lb1", aliases })
         collapse-before-ad-fetch=true
         modifiers=["top-of-page", "center", "max-width-970"]
-      /> -->
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/packages/shared/templates/website-section/membership.marko
+++ b/packages/shared/templates/website-section/membership.marko
@@ -21,12 +21,12 @@ $ const {
   <@page>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <shared-leaderboard-block />
-      <!-- <marko-web-gam-define-display-ad
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
         ...GAM.getAdUnit({ name: "lb1", aliases })
         collapse-before-ad-fetch=true
         modifiers=["top-of-page", "center", "max-width-970"]
-      /> -->
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/sites/bcvs.hub.heart.org/config/gam.js
+++ b/sites/bcvs.hub.heart.org/config/gam.js
@@ -5,6 +5,7 @@ const config = configureGAM({ basePath: 'hearthubs' });
 config
   .setAliasAdUnits('default', [
     { name: 'lb1', templateName: 'LB', path: 'lb1' },
+    { name: 'lb2', templateName: 'LB', path: 'lb2' },
     { name: 'rail1', templateName: 'RAIL1', path: 'rail1' },
     { name: 'rail2', templateName: 'RAIL1', path: 'rail2' },
   ]);

--- a/sites/bcvs.hub.heart.org/server/templates/index.marko
+++ b/sites/bcvs.hub.heart.org/server/templates/index.marko
@@ -20,7 +20,13 @@ $ const {
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
 
-      <shared-leaderboard-block />
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
+        ...GAM.getAdUnit({ name: "lb1", aliases })
+        modifiers=["top-of-page", "max-width-970", "center", "paid"]
+        collapse-before-ad-fetch=true
+        with-wrapper=true
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/sites/bcvs.hub.heart.org/server/templates/website-section/2020-program.marko
+++ b/sites/bcvs.hub.heart.org/server/templates/website-section/2020-program.marko
@@ -20,12 +20,13 @@ $ const {
     <a class="anchor" name="top" />
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <shared-leaderboard-block />
-      <!-- <marko-web-gam-define-display-ad
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
         ...GAM.getAdUnit({ name: "lb1", aliases })
+        modifiers=["top-of-page", "max-width-970", "center", "paid"]
         collapse-before-ad-fetch=true
-        modifiers=["top-of-page", "center", "max-width-970"]
-      /> -->
+        with-wrapper=true
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/sites/hypertension.hub.heart.org/config/gam.js
+++ b/sites/hypertension.hub.heart.org/config/gam.js
@@ -5,6 +5,7 @@ const config = configureGAM({ basePath: 'hearthubs' });
 config
   .setAliasAdUnits('default', [
     { name: 'lb1', templateName: 'LB', path: 'lb1' },
+    { name: 'lb2', templateName: 'LB', path: 'lb2' },
     { name: 'rail1', templateName: 'RAIL1', path: 'rail1' },
     { name: 'rail2', templateName: 'RAIL1', path: 'rail2' },
   ]);

--- a/sites/hypertension.hub.heart.org/server/templates/index.marko
+++ b/sites/hypertension.hub.heart.org/server/templates/index.marko
@@ -20,7 +20,12 @@ $ const {
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
 
-      <shared-leaderboard-block />
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
+      ...GAM.getAdUnit({ name: "lb1" })
+      class="mt-block"
+      modifiers=["max-width-970", "top-of-page", "center"]
+    />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/sites/hypertension.hub.heart.org/server/templates/website-section/2020-program.marko
+++ b/sites/hypertension.hub.heart.org/server/templates/website-section/2020-program.marko
@@ -20,12 +20,13 @@ $ const {
     <a class="anchor" name="top" />
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <shared-leaderboard-block />
-      <!-- <marko-web-gam-define-display-ad
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
         ...GAM.getAdUnit({ name: "lb1", aliases })
+        modifiers=["top-of-page", "max-width-970", "center", "paid"]
         collapse-before-ad-fetch=true
-        modifiers=["top-of-page", "center", "max-width-970"]
-      /> -->
+        with-wrapper=true
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/sites/isc.hub.heart.org/server/templates/website-section/2020-program.marko
+++ b/sites/isc.hub.heart.org/server/templates/website-section/2020-program.marko
@@ -20,12 +20,13 @@ $ const {
     <a class="anchor" name="top" />
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <shared-leaderboard-block />
-      <!-- <marko-web-gam-define-display-ad
+      <!-- <shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
         ...GAM.getAdUnit({ name: "lb1", aliases })
+        modifiers=["top-of-page", "max-width-970", "center", "paid"]
         collapse-before-ad-fetch=true
-        modifiers=["top-of-page", "center", "max-width-970"]
-      /> -->
+        with-wrapper=true
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/sites/qcor.hub.heart.org/config/gam.js
+++ b/sites/qcor.hub.heart.org/config/gam.js
@@ -5,6 +5,7 @@ const config = configureGAM({ basePath: 'hearthubs' });
 config
   .setAliasAdUnits('default', [
     { name: 'lb1', templateName: 'LB', path: 'lb1' },
+    { name: 'lb2', templateName: 'LB', path: 'lb2' },
     { name: 'rail1', templateName: 'RAIL1', path: 'rail1' },
     { name: 'rail2', templateName: 'RAIL1', path: 'rail2' },
   ]);

--- a/sites/qcor.hub.heart.org/server/templates/index.marko
+++ b/sites/qcor.hub.heart.org/server/templates/index.marko
@@ -32,13 +32,13 @@ $ const {
         <div class="col-lg-8 mb-block-lg">
           <shared-content-hero-card-block section-id=id />
 
-          <!--<shared-qcor-early-career-plenary-buttons-block />-->
-          <marko-web-gam-define-display-ad
+          <shared-qcor-early-career-plenary-buttons-block />
+          <!--<marko-web-gam-define-display-ad
             ...GAM.getAdUnit({ name: "lb2", aliases })
             modifiers=["max-width-970", "center", "paid"]
             collapse-before-ad-fetch=true
             with-wrapper=true
-          />
+          />-->
 
           <!-- <shared-event-schedule-block class="mb-block-lg">
             <@header>

--- a/sites/qcor.hub.heart.org/server/templates/index.marko
+++ b/sites/qcor.hub.heart.org/server/templates/index.marko
@@ -20,13 +20,25 @@ $ const {
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
 
-      <shared-leaderboard-block />
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
+        ...GAM.getAdUnit({ name: "lb1", aliases })
+        modifiers=["top-of-page", "max-width-970", "center", "paid"]
+        collapse-before-ad-fetch=true
+        with-wrapper=true
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">
           <shared-content-hero-card-block section-id=id />
 
-          <shared-qcor-early-career-plenary-buttons-block />
+          <!--<shared-qcor-early-career-plenary-buttons-block />-->
+          <marko-web-gam-define-display-ad
+            ...GAM.getAdUnit({ name: "lb2", aliases })
+            modifiers=["max-width-970", "center", "paid"]
+            collapse-before-ad-fetch=true
+            with-wrapper=true
+          />
 
           <!-- <shared-event-schedule-block class="mb-block-lg">
             <@header>

--- a/sites/qcor.hub.heart.org/server/templates/website-section/2020-program.marko
+++ b/sites/qcor.hub.heart.org/server/templates/website-section/2020-program.marko
@@ -20,12 +20,12 @@ $ const {
     <a class="anchor" name="top" />
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <shared-leaderboard-block />
-      <!-- <marko-web-gam-define-display-ad
+      <!-- <shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
         ...GAM.getAdUnit({ name: "lb1", aliases })
         collapse-before-ad-fetch=true
         modifiers=["top-of-page", "center", "max-width-970"]
-      /> -->
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/sites/vasculardiscovery.hub.heart.org/config/gam.js
+++ b/sites/vasculardiscovery.hub.heart.org/config/gam.js
@@ -5,6 +5,7 @@ const config = configureGAM({ basePath: 'hearthubs' });
 config
   .setAliasAdUnits('default', [
     { name: 'lb1', templateName: 'LB', path: 'lb1' },
+    { name: 'lb2', templateName: 'LB', path: 'lb2' },
     { name: 'rail1', templateName: 'RAIL1', path: 'rail1' },
     { name: 'rail2', templateName: 'RAIL1', path: 'rail2' },
   ]);

--- a/sites/vasculardiscovery.hub.heart.org/server/templates/index.marko
+++ b/sites/vasculardiscovery.hub.heart.org/server/templates/index.marko
@@ -20,7 +20,14 @@ $ const {
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
 
-      <shared-leaderboard-block />
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
+        ...GAM.getAdUnit({ name: "lb1", aliases })
+        modifiers=["top-of-page", "max-width-970", "center", "paid"]
+        collapse-before-ad-fetch=true
+        with-wrapper=true
+      />
+
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">

--- a/sites/vasculardiscovery.hub.heart.org/server/templates/website-section/2020-program.marko
+++ b/sites/vasculardiscovery.hub.heart.org/server/templates/website-section/2020-program.marko
@@ -20,12 +20,12 @@ $ const {
     <a class="anchor" name="top" />
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <shared-leaderboard-block />
-      <!-- <marko-web-gam-define-display-ad
-        ...GAM.getAdUnit({ name: "lb1", aliases })
-        collapse-before-ad-fetch=true
-        modifiers=["top-of-page", "center", "max-width-970"]
-      /> -->
+      <!--<shared-leaderboard-block />-->
+      <marko-web-gam-define-display-ad
+        ...GAM.getAdUnit({ name: "lb1" })
+        class="mt-block"
+        modifiers=["max-width-970", "top-of-page", "center"]
+      />
 
       <div class="row">
         <div class="col-lg-8 mb-block-lg">


### PR DESCRIPTION
This will require setup of new GAM containers for all 4 of these sites. I did some testing using a pre-existing container for Vascular that contained the necessary units to fill (see screenshots). So this will need to be updated once those containers are made but the majority of this will remain the same as the ad unit codes will be the same across the sites just not the container code (hearthubs will get changed to vascular for Vascular Discovery etc.)


<img width="1920" alt="Screen Shot 2021-08-18 at 9 25 50 AM" src="https://user-images.githubusercontent.com/46794001/129920922-4ff5f99e-3d64-4ca2-82a7-2ccf4bd104e5.png">
<img width="1920" alt="Screen Shot 2021-08-18 at 9 25 57 AM" src="https://user-images.githubusercontent.com/46794001/129920937-eea56295-d484-4409-be24-f9f357434328.png">
