### PR TITLE
Update focus styling ISC for all focusable elements.

### DIFF
--- a/sites/isc.hub.heart.org/server/styles/index.scss
+++ b/sites/isc.hub.heart.org/server/styles/index.scss
@@ -30,3 +30,19 @@ $theme-site-navbar-secondary-type: dark;
   text-align: center;
   text-transform: uppercase;
 }
+
+a:focus,
+area:focus,
+input:not([disabled]):focus,
+select:not([disabled]):focus,
+textarea:not([disabled]):focus,
+button:not([disabled]):focus,
+iframe:focus,
+[tabindex],
+[contentEditable="true"]
+{
+  &:not([tabindex="-1"])
+  {
+    border: medium solid #000;
+  }
+}


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-08-30 at 8 24 24 AM" src="https://user-images.githubusercontent.com/46794001/131346438-c4b1c593-58c0-4937-9ee8-a81f4bafd891.png">


Modification made from: https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus