### PR TITLE
Update all heart sites to use shared vascular ad units

### DIFF
--- a/sites/bcvs.hub.heart.org/config/gam.js
+++ b/sites/bcvs.hub.heart.org/config/gam.js
@@ -4,10 +4,10 @@ const config = configureGAM({ basePath: 'hearthubs' });
 
 config
   .setAliasAdUnits('default', [
-    { name: 'lb1', templateName: 'LB', path: 'lb1' },
-    { name: 'lb2', templateName: 'LB', path: 'lb2' },
-    { name: 'rail1', templateName: 'RAIL1', path: 'rail1' },
-    { name: 'rail2', templateName: 'RAIL1', path: 'rail2' },
+    { name: 'lb1', templateName: 'LB', path: 'vascular-lb1' },
+    { name: 'lb2', templateName: 'LB', path: 'vascular-lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'vascular-rail1' },
+    { name: 'rail2', templateName: 'RAIL1', path: 'vascular-rail2' },
   ]);
 
 module.exports = config;

--- a/sites/hypertension.hub.heart.org/config/gam.js
+++ b/sites/hypertension.hub.heart.org/config/gam.js
@@ -4,10 +4,10 @@ const config = configureGAM({ basePath: 'hearthubs' });
 
 config
   .setAliasAdUnits('default', [
-    { name: 'lb1', templateName: 'LB', path: 'lb1' },
-    { name: 'lb2', templateName: 'LB', path: 'lb2' },
-    { name: 'rail1', templateName: 'RAIL1', path: 'rail1' },
-    { name: 'rail2', templateName: 'RAIL1', path: 'rail2' },
+    { name: 'lb1', templateName: 'LB', path: 'vascular-lb1' },
+    { name: 'lb2', templateName: 'LB', path: 'vascular-lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'vascular-rail1' },
+    { name: 'rail2', templateName: 'RAIL1', path: 'vascular-rail2' },
   ]);
 
 module.exports = config;

--- a/sites/qcor.hub.heart.org/config/gam.js
+++ b/sites/qcor.hub.heart.org/config/gam.js
@@ -4,10 +4,10 @@ const config = configureGAM({ basePath: 'hearthubs' });
 
 config
   .setAliasAdUnits('default', [
-    { name: 'lb1', templateName: 'LB', path: 'lb1' },
-    { name: 'lb2', templateName: 'LB', path: 'lb2' },
-    { name: 'rail1', templateName: 'RAIL1', path: 'rail1' },
-    { name: 'rail2', templateName: 'RAIL1', path: 'rail2' },
+    { name: 'lb1', templateName: 'LB', path: 'vascular-lb1' },
+    { name: 'lb2', templateName: 'LB', path: 'vascular-lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'vascular-rail1' },
+    { name: 'rail2', templateName: 'RAIL1', path: 'vascular-rail2' },
   ]);
 
 module.exports = config;

--- a/sites/vasculardiscovery.hub.heart.org/config/gam.js
+++ b/sites/vasculardiscovery.hub.heart.org/config/gam.js
@@ -4,10 +4,10 @@ const config = configureGAM({ basePath: 'hearthubs' });
 
 config
   .setAliasAdUnits('default', [
-    { name: 'lb1', templateName: 'LB', path: 'lb1' },
-    { name: 'lb2', templateName: 'LB', path: 'lb2' },
-    { name: 'rail1', templateName: 'RAIL1', path: 'rail1' },
-    { name: 'rail2', templateName: 'RAIL1', path: 'rail2' },
+    { name: 'lb1', templateName: 'LB', path: 'vascular-lb1' },
+    { name: 'lb2', templateName: 'LB', path: 'vascular-lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'vascular-rail1' },
+    { name: 'rail2', templateName: 'RAIL1', path: 'vascular-rail2' },
   ]);
 
 module.exports = config;


### PR DESCRIPTION
When we converted them from static to gam ads we used the standard lb1, lb2, rail1 rail2.  They currently have a shared verison under vascular-${unit} so until they need or want to separate the ads/ad units we can use this one.

<img width="1307" alt="Screen Shot 2021-09-09 at 8 45 29 AM" src="https://user-images.githubusercontent.com/3845869/132698389-2466df4f-2357-4a99-a29e-b519a4c4e75d.png">
