### PR TITLE
Fix rectangular gap appearing in load-more section

### DIFF
--- a/packages/global/templates/website-section/index.marko
+++ b/packages/global/templates/website-section/index.marko
@@ -94,7 +94,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
             sectionId: id,
             optionName: ["Standard"],
             excludeContentIds: sectionContent.ids,
-            limit: 12,
+            limit: 11,
           };
           <marko-web-load-more
             component-name="global-content-card-deck-flow"


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-09-23 at 11 51 45 AM" src="https://user-images.githubusercontent.com/46794001/134552134-7b60a8e8-bcfc-4e14-9ff1-4ec96941a61e.png">
