### PR TITLE
Change menu toggle button to a button element.

### DIFF
--- a/packages/global/components/site-header.marko
+++ b/packages/global/components/site-header.marko
@@ -43,6 +43,7 @@ $ if (navigation.secondary.length) tertiaryMods.push("no-left-margin");
     <if(navigation.menu.length)>
       <default-theme-menu-toggle-button
         class-name="site-navbar__toggler"
+        tag="button"
         targets=[".site-menu"]
         toggle-class="site-menu--open"
         icon-modifiers=["lg"]


### PR DESCRIPTION
Currently on production (didn't appear to be an issue on dev for whatever reason in terms of actually interacting with it) this is a div making it where it can't be "tab targeted" this resolves that issue and makes it so it can be tab targeted.

<img width="1920" alt="Screen Shot 2021-10-27 at 8 49 12 AM" src="https://user-images.githubusercontent.com/46794001/139079023-5af6a526-ba5b-4470-9dbf-584b6ea85c99.png">
