### PR TITLE
Change modal to standard ProfileLink. IMEX

### DIFF
--- a/packages/daily/components/company-page/website-link.marko
+++ b/packages/daily/components/company-page/website-link.marko
@@ -1,11 +1,10 @@
 import { get, getAsObject } from "@parameter1/base-cms-object-path";
 
-$ const { id, name } = getAsObject(input, "company");
-$ const href = get(input, "company.website");
+$ const { website: href, id: companyId, name: companyName } = getAsObject(input, "company");
 $ const props = {
   href,
-  label: "Visit Site",
-  classNames: "btn btn-sm btn-primary btn-block",
+  companyId,
+  companyName
 };
 
 <if(href)>

--- a/packages/daily/components/company-page/website-link.marko
+++ b/packages/daily/components/company-page/website-link.marko
@@ -9,5 +9,5 @@ $ const props = {
 };
 
 <if(href)>
-  <marko-web-browser-component name="JumpModal" props=props />
+  <marko-web-browser-component name="CompanyProfileWebsiteLink" props=props />
 </if>


### PR DESCRIPTION
This package is only used by the IMEX site as far as I can tell so this change should be safe to just deploy. Not sure why there was modal behavior for this previously but it has now been updated to a regular Company Website Link.