### PR TITLE
Use stacked header logo to account for resizing on mobile. ASHP

### DIFF
--- a/sites/ashp.org/config/logos.js
+++ b/sites/ashp.org/config/logos.js
@@ -1,8 +1,8 @@
 module.exports = {
   navbar: {
-    src: 'https://img.ascendmedia.com/files/base/ascend/hh/image/static/ashp/ashp_header_revision.png?h=200',
+    src: 'https://img.ascendmedia.com/files/base/ascend/hh/image/static/ashp/ashp_header_revision_stacked.png?h=200',
     srcset: [
-      'https://img.ascendmedia.com/files/base/ascend/hh/image/static/ashp/ashp_header_revision.png?h=400 2x',
+      'https://img.ascendmedia.com/files/base/ascend/hh/image/static/ashp/ashp_header_revision_stacked.png?h=400 2x',
     ],
     href: '/',
     title: 'Example Site',

--- a/sites/ashp.org/server/styles/index.scss
+++ b/sites/ashp.org/server/styles/index.scss
@@ -4,7 +4,7 @@ $primary: #006eb7;
 $secondary: #f47932;
 
 $theme-site-navbar-logo-height: 100px;
-$theme-site-navbar-logo-height-sm: 45px;
+$theme-site-navbar-logo-height-sm: 30px;
 $theme-site-footer-logo-height: 100px;
 $theme-site-footer-primary-bg-color: $primary;
 $theme-site-footer-secondary-bg-color: $primary;

--- a/sites/ashp.org/server/styles/index.scss
+++ b/sites/ashp.org/server/styles/index.scss
@@ -4,7 +4,7 @@ $primary: #006eb7;
 $secondary: #f47932;
 
 $theme-site-navbar-logo-height: 100px;
-$theme-site-navbar-logo-height-sm: 30px;
+$theme-site-navbar-logo-height-sm: 45px;
 $theme-site-footer-logo-height: 100px;
 $theme-site-footer-primary-bg-color: $primary;
 $theme-site-footer-secondary-bg-color: $primary;


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-11-04 at 9 47 06 AM" src="https://user-images.githubusercontent.com/46794001/140335572-48e555fc-fc60-4ee6-8bc4-ee5bd594ca36.png">
<img width="1920" alt="Screen Shot 2021-11-04 at 9 47 27 AM" src="https://user-images.githubusercontent.com/46794001/140335582-dcdf9900-21f8-4a3b-aeb7-136c01adb932.png">

(Additional screenshots for just before and just after breakpoint)

<img width="1919" alt="Screen Shot 2021-11-04 at 9 50 22 AM" src="https://user-images.githubusercontent.com/46794001/140336144-d8150941-fab6-4e21-b148-a479814e2d87.png">
<img width="1920" alt="Screen Shot 2021-11-04 at 9 50 29 AM" src="https://user-images.githubusercontent.com/46794001/140336154-ed6513c8-9bf8-477b-a3b6-a6c8d1ec2d32.png">

