### PR TITLE
Add native-x init to document head of global theme

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -1,6 +1,6 @@
 import { getAsObject, get } from "@parameter1/base-cms-object-path";
 
-$ const { site, req, GAM, config } = out.global;
+$ const { site, req, GAM, nativeX, config } = out.global;
 $ const { NODE_ENV } = process.env;
 $ const aboveContainer = get(input, "aboveContainer.renderBody");
 
@@ -13,6 +13,7 @@ $ const aboveContainer = get(input, "aboveContainer.renderBody");
     <marko-web-deferred-script-loader-init />
     <marko-web-gam-init />
     <marko-web-gtm-init container-id=site.get("gtm.containerId") />
+    <marko-web-native-x-init uri=nativeX.getUri() enabled=nativeX.isEnabled() />
     <marko-web-gtm-push data={ env: NODE_ENV } />
     <${input.head} />
     <marko-web-gtm-start />


### PR DESCRIPTION
This had been corrected here: https://github.com/parameter1/ascend-media-websites/pull/224

It was subsequently "broken" here https://github.com/parameter1/ascend-media-websites/pull/242 as at the time the port had happened the new theme (more specifically sites using the new theme) hadn't/weren't configured or using Native-X which would explain why this was missed in the initial port (include the homepage placement as again at the time there wasn't any site using Native-X)