### PR TITLE
Add load more to content pages.

### DIFF
--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -227,4 +227,28 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && ["document", "p
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
+
+  <@below-page>
+    <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection")
+      $ const aliases = hierarchyAliases(section);
+      $ const loadMoreParams = {
+        sectionId: section.id,
+        optionName: ["Standard"],
+        excludeContentIds: [id],
+        limit: 11,
+      };
+      <marko-web-load-more
+        component-name="global-content-card-deck-flow"
+        component-input={ aliases, cols: 3, withTeaser: false, adName: 'load-more', adIndex: 0 }
+        fragment-name="global-content-list"
+        query-name="website-scheduled-content"
+        query-params=loadMoreParams
+        max-pages=3
+        page-input={ for: "content", id }
+        attrs={ "aria-label": "load-more", "role": "main" }
+      />
+    </marko-web-resolve-page>
+  </@below-page>
+
 </marko-web-content-page-layout>


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2022-04-28 at 3 34 00 PM" src="https://user-images.githubusercontent.com/46794001/165840930-50136c58-304f-4c4b-8683-21ade066a5dc.png">
