### PR TITLE
Add native ad block to homepage & revert back to original 'right rail' on content pages

### DIFF
--- a/packages/global/components/blocks/right-rail.marko
+++ b/packages/global/components/blocks/right-rail.marko
@@ -9,18 +9,7 @@ $ const nativeXBlock = site.get('nativeXBlock');
   class="mb-block"
 />
 
-<if(nativeXBlock === true)>
-  <global-native-x-list-block
-    placement-name="default"
-    aliases=aliases
-    limit=6
-    collapsible=true
-  />
-</if>
-
-<else>
-  <global-twitter-widget-block />
-</else>
+<global-twitter-widget-block />
 
 <marko-web-gam-define-display-ad
 ...GAM.getAdUnit({ name: 'rail2', aliases })

--- a/packages/global/components/blocks/right-rail.marko
+++ b/packages/global/components/blocks/right-rail.marko
@@ -9,7 +9,18 @@ $ const nativeXBlock = site.get('nativeXBlock');
   class="mb-block"
 />
 
-<global-twitter-widget-block />
+<if(nativeXBlock === true)>
+  <global-native-x-list-block
+    placement-name="default"
+    aliases=aliases
+    limit=6
+    collapsible=true
+  />
+</if>
+
+<else>
+  <global-twitter-widget-block />
+</else>
 
 <marko-web-gam-define-display-ad
 ...GAM.getAdUnit({ name: 'rail2', aliases })

--- a/packages/global/templates/website-section/home.marko
+++ b/packages/global/templates/website-section/home.marko
@@ -73,14 +73,9 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8">
-            <if(!nativeXBlock === true)>
-              <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 4)>
-                <@native-x index=0 name="default" />
-              </global-content-card-deck-flow>
-            </if>
-            <else>
-              <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 4) />
-            </else>
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 4)>
+              <@native-x index=0 name="default" />
+            </global-content-card-deck-flow>
           </div>
           <div class="col-lg-4">
             <if(nativeXBlock === true)>


### PR DESCRIPTION
<img width="930" alt="Screen Shot 2022-05-04 at 8 31 42 AM" src="https://user-images.githubusercontent.com/64623209/166693758-e5608ec6-5dd8-4f53-b117-e4b464a39db6.png">
Reverted Changes back to having 'Interesting Stories' block on content pages:
<img width="861" alt="Screen Shot 2022-05-04 at 9 30 05 AM" src="https://user-images.githubusercontent.com/64623209/166703736-2a3505a0-5a29-4d1b-8154-6d05bc994f21.png">
