### PR TITLE
Enable Company Event Reporting

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -11,6 +11,11 @@ $ const aboveContainer = get(input, "aboveContainer.renderBody");
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
     <marko-web-deferred-script-loader-init />
+    <marko-web-p1-events-init
+      on="load"
+      request-frame=true
+      target-tag="body"
+    />
     <marko-web-gam-init
       on="ready"
       request-frame=true

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -21,6 +21,7 @@
     "@parameter1/base-cms-marko-web-icons": "^2.46.3",
     "@parameter1/base-cms-marko-web-inquiry": "^2.92.0",
     "@parameter1/base-cms-marko-web-native-x": "^2.88.0",
+    "@parameter1/base-cms-marko-web-p1-events": "^2.77.0",
     "@parameter1/base-cms-marko-web-photoswipe": "^2.92.0",
     "@parameter1/base-cms-marko-web-social-sharing": "^2.92.0",
     "@parameter1/base-cms-marko-web-theme-default": "^2.91.0",

--- a/packages/global/templates/content/company.marko
+++ b/packages/global/templates/content/company.marko
@@ -17,6 +17,7 @@ $ const adSlots = ({ aliases }) => ({
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       <marko-web-gam-slots slots=adSlots({ aliases }) />
+      <marko-web-p1-events-track-content node=content />
     </marko-web-resolve-page>
   </@head>
 

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -38,6 +38,7 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && ["document", "p
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       <marko-web-gam-slots slots=adSlots({ aliases }) />
+      <marko-web-p1-events-track-content node=content />
     </marko-web-resolve-page>
   </@head>
 

--- a/sites/aadmeetingnews.org/config/site.js
+++ b/sites/aadmeetingnews.org/config/site.js
@@ -47,4 +47,9 @@ module.exports = {
     logo: 'https://img.ascendmedia.com/files/base/ascend/hh/image/static/aad/AAD_Logo_Header.pngh=50',
     bgColor: '#ffffff',
   },
+  p1events: {
+    tenant: 'ascend',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'aadmeetingnews.org' : '',
+  },
 };

--- a/sites/aao.hns.org/config/site.js
+++ b/sites/aao.hns.org/config/site.js
@@ -47,4 +47,9 @@ module.exports = {
     logo: '',
     bgColor: '#ffffff',
   },
+  p1events: {
+    tenant: 'ascend',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'aaohnsfmeetingnewscentral.org' : '',
+  },
 };

--- a/sites/acep.org/config/site.js
+++ b/sites/acep.org/config/site.js
@@ -48,4 +48,9 @@ module.exports = {
     logo: '',
     bgColor: '#ffffff',
   },
+  p1events: {
+    tenant: 'ascend',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'acepmeetingnewscentral.org' : '',
+  },
 };

--- a/sites/asa.org/config/site.js
+++ b/sites/asa.org/config/site.js
@@ -48,4 +48,9 @@ module.exports = {
     logo: '',
     bgColor: '#ffffff',
   },
+  p1events: {
+    tenant: 'ascend',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'asameetingnewscentral.org' : '',
+  },
 };

--- a/sites/ashp.org/config/site.js
+++ b/sites/ashp.org/config/site.js
@@ -47,4 +47,9 @@ module.exports = {
     logo: '',
     bgColor: '#ffffff',
   },
+  p1events: {
+    tenant: 'ascend',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'ashpmidyeardailynews.org' : '',
+  },
 };

--- a/sites/auadailynews.org/config/site.js
+++ b/sites/auadailynews.org/config/site.js
@@ -45,4 +45,9 @@ module.exports = {
     logo: 'https://img.ascendmedia.com/files/base/ascend/hh/image/static/aua/site_logo.png?h=50',
     bgColor: '#ffffff',
   },
+  p1events: {
+    tenant: 'ascend',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'auadailynews.org' : '',
+  },
 };

--- a/sites/isc.hub.heart.org/config/site.js
+++ b/sites/isc.hub.heart.org/config/site.js
@@ -53,6 +53,11 @@ module.exports = {
     logo: 'https://img.hub.heart.org/files/base/ascend/hearthub/image/static/footer.svg?h=90',
     bgColor: '#ffffff',
   },
+  p1events: {
+    tenant: 'ascend',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'isc.hub.heart.org' : '',
+  },
   ahaFooter: true,
   noticePushdown: true,
 };

--- a/sites/sessions.hub.heart.org/config/site.js
+++ b/sites/sessions.hub.heart.org/config/site.js
@@ -55,6 +55,11 @@ module.exports = {
     logo: 'https://img.hub.heart.org/files/base/ascend/hearthub/image/static/footer.svg?h=90',
     bgColor: '#ffffff',
   },
+  p1events: {
+    tenant: 'ascend',
+    enabled: true,
+    cookieDomain: process.env.NODE_ENV === 'production' ? 'sessions.hub.heart.org' : '',
+  },
   ahaFooter: true,
   noticePushdown: true,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2593,6 +2593,15 @@
     graphql-tag "^2.12.5"
     node-fetch "^2.6.5"
 
+"@parameter1/base-cms-marko-web-p1-events@^2.77.0":
+  version "2.77.0"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-p1-events/-/base-cms-marko-web-p1-events-2.77.0.tgz#2c2e3e597d8bed33b8211bc8519bb3a415f27281"
+  integrity sha512-s5LQhGBthy3IYjt1X6pM9gVb/7pFwe3d7wzmTXoz+r7xtkGzWfIvxyAXtZ57w0j+uSZW/7EjVkRtRpDIxppX2g==
+  dependencies:
+    "@parameter1/base-cms-inflector" "^2.0.0"
+    "@parameter1/base-cms-marko-web-deferred-script-loader" "^2.77.0"
+    "@parameter1/base-cms-object-path" "^2.75.1"
+
 "@parameter1/base-cms-marko-web-photoswipe@^2.92.0":
   version "2.92.0"
   resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-photoswipe/-/base-cms-marko-web-photoswipe-2.92.0.tgz#e5d6862689cbacdcc44ab606b10fc59ff0ec638b"


### PR DESCRIPTION
![p1-events-firing-sessions](https://user-images.githubusercontent.com/46794001/179566848-61271597-f1e8-41d9-8027-b748a2dfce1e.png)


This PR will only enable it on Global Theme sites. 

This DOES NOT include the following:

IMEX and IMEX Frankfurt (Utilize package-daily)
Bulletin (Utilizes package-shared)
BCVS (Utilizes package-shared)
Hypertension (Utilizes package-shared)
QCOR (Utilizes package-shared)
Vascular Discovery (Utilizes package-shared)

Any sites using package-shared are updated to use package-daily here: https://github.com/parameter1/ascend-media-websites/pull/337 and a subsequent PR to enable this behavior for package-daily will be opened following the previously mentioned PR being merged.