### PR TITLE
Enable Featured Exhibitors Sessions

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -2,6 +2,7 @@ import Vue from '@parameter1/base-cms-marko-web/browser/vue';
 import VModal from 'vue-js-modal/dist/index.nocss';
 import jQuery from '@parameter1/base-cms-marko-web/browser/jquery-full';
 
+import RevealAd from '@parameter1/base-cms-marko-web-reveal-ad/browser';
 import Inquiry from '@parameter1/base-cms-marko-web-inquiry/browser';
 import DefaultTheme from '@parameter1/base-cms-marko-web-theme-default/browser';
 import GTM from '@parameter1/base-cms-marko-web-gtm/browser';
@@ -24,6 +25,7 @@ export default (Browser) => {
   GTM(Browser);
   GAM(Browser);
   GCSE(Browser);
+  RevealAd(Browser);
   SocialSharing(Browser);
   PhotoSwipe(Browser);
   Inquiry(Browser);

--- a/packages/global/components/blocks/featured-exhibitors.marko
+++ b/packages/global/components/blocks/featured-exhibitors.marko
@@ -1,0 +1,52 @@
+import { getAsObject, get } from "@parameter1/base-cms-object-path";
+import queryFragment from "../../graphql/fragments/featured-exhibitors";
+
+$ const { sectionAlias } = input;
+
+$ const queryParams = {
+  limit: 12,
+  queryFragment,
+  sectionBubbling: false,
+  requiresImage: true,
+  includeContentTypes: ["Company"],
+  ...getAsObject(input, "queryParams"),
+  sectionAlias,
+};
+
+<marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+  <marko-web-node-list>
+    <@header>
+      Featured Exhibitors
+    </@header>
+    <@body>
+      Click on a logo to visit these exhibitors
+    </@body>
+    <@nodes nodes=nodes>
+      <default-theme-card-deck-flow cols=4 nodes=nodes modifiers=["featured-exhibitors"]>
+        <@slot|{ node: content }|>
+          $ const primaryImage = getAsObject(content, "primaryImage");
+          <marko-web-node
+            type=`${content.type}-content`
+            image-position="top"
+            card=true
+            flush=false
+            full-height=false
+            modifiers=["no-shadow"]
+          >
+            <@image
+              ar="16:9"
+              width="300"
+              fluid=true
+              use-placeholder=false
+              src=primaryImage.src
+              alt=primaryImage.alt
+              is-logo=true
+              link={ href: get(content, "siteContext.path") }
+            />
+          </marko-web-node>
+        </@slot>
+      </default-theme-card-deck-flow>
+    </@nodes>
+  </marko-web-node-list>
+
+</marko-web-query>

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -67,5 +67,8 @@
   },
   "<global-native-x-list-block>": {
     "template": "./native-x-list.marko"
+  },
+  "<global-featured-exhibitors-block>": {
+    "template": "./featured-exhibitors.marko"
   }
 }

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -40,13 +40,14 @@ $ const aboveContainer = get(input, "aboveContainer.renderBody");
     <marko-web-browser-component name="TriggerScreenChangeEvent" />
     <marko-web-gtm-track-bus-event on="screen_change" />
     <marko-web-gtm-track-load-more />
-
+    <marko-web-reveal-ad-listener select-all-targets=true />
     <global-site-header />
     <default-theme-site-menu modifiers=["right"] />
     <if(site.config.noticePushdown)>
       <global-notice-pushdown-block />
     </if>
   </@above-container>
+   <${input.aboveContainer} />
   <@below-container>
     <${input.belowContainer} />
     <if(site.config.ahaFooter)>

--- a/packages/global/graphql/fragments/featured-exhibitors.js
+++ b/packages/global/graphql/fragments/featured-exhibitors.js
@@ -1,0 +1,19 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment WebsiteContentFeaturedExhibitorsFragment on Content {
+  id
+  type
+  primaryImage {
+    id
+    src
+    alt
+    isLogo
+  }
+  siteContext {
+    path
+  }
+}
+
+`;

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -22,6 +22,7 @@
     "@parameter1/base-cms-marko-web-inquiry": "^2.92.0",
     "@parameter1/base-cms-marko-web-native-x": "^2.88.0",
     "@parameter1/base-cms-marko-web-photoswipe": "^2.92.0",
+    "@parameter1/base-cms-marko-web-reveal-ad": "^2.45.0",
     "@parameter1/base-cms-marko-web-social-sharing": "^2.92.0",
     "@parameter1/base-cms-marko-web-theme-default": "^2.91.0",
     "@parameter1/base-cms-object-path": "^2.75.1",

--- a/packages/global/scss/components/_ad-container.scss
+++ b/packages/global/scss/components/_ad-container.scss
@@ -37,5 +37,4 @@
 
 .reveal-ad-background + .body-wrapper {
   background-image: none;
-  z-index: 1;
 }

--- a/packages/global/scss/components/_ad-container.scss
+++ b/packages/global/scss/components/_ad-container.scss
@@ -34,3 +34,8 @@
     }
   }
 }
+
+.reveal-ad-background + .body-wrapper {
+  background-image: none;
+  z-index: 1;
+}

--- a/packages/global/scss/components/_site-footer.scss
+++ b/packages/global/scss/components/_site-footer.scss
@@ -39,3 +39,7 @@
     }
   }
 }
+
+#aha-footer {
+  position: relative;
+}

--- a/packages/global/scss/theme.scss
+++ b/packages/global/scss/theme.scss
@@ -6,6 +6,7 @@
 $pswp__root-z-index: $theme-site-header-z-index + 1 !default;
 @import "../../node_modules/@parameter1/base-cms-marko-web-photoswipe/scss/main";
 @import "../../node_modules/@parameter1/base-cms-marko-web-social-sharing/scss/buttons";
+@import "../../node_modules/@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
 
 // vue-modal styles
 @import "./components/vue-modal";

--- a/packages/global/templates/content/company.marko
+++ b/packages/global/templates/content/company.marko
@@ -6,6 +6,7 @@ $ const { id, type, pageNode } = data;
 
 $ const adSlots = ({ aliases }) => ({
   "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
 });
 
 <marko-web-content-page-layout id=id type=type attrs={"aria-label": `website-section-${id}`}>
@@ -19,7 +20,12 @@ $ const adSlots = ({ aliases }) => ({
       <marko-web-gam-slots slots=adSlots({ aliases }) />
     </marko-web-resolve-page>
   </@head>
-
+  <@above-container>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
+    </marko-web-resolve-page>
+  </@above-container>
   <@page>
     <!-- <global-leaderboard-block /> -->
     <!-- <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page", "max-width-790", "center"] /> -->
@@ -66,8 +72,14 @@ $ const adSlots = ({ aliases }) => ({
               </@body>
             </marko-web-node-list>
           </if>
+          <if(site.get("featuredExhibitors"))>
+            <marko-web-gam-display-ad id="gpt-ad-rail1" />
+          </if>
         </div>
       </div>
+      <if(site.get("featuredExhibitors"))>
+        <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["max-width-790", "center"] />
+      </if>
     </marko-web-resolve-page>
   </@page>
   <@below-page>

--- a/packages/global/templates/content/company.marko
+++ b/packages/global/templates/content/company.marko
@@ -65,7 +65,7 @@ $ const adSlots = ({ aliases }) => ({
           />
 
           <if(resolved.get("enableRmi"))>
-            <marko-web-node-list collapsible=false modifiers=["sticky-top"]>
+            <marko-web-node-list collapsible=false>
               <@header>Request More Information</@header>
               <@body>
                 <marko-web-inquiry-form content=content with-header=false modifiers=["right-rail"] />

--- a/sites/sessions.hub.heart.org/config/gam.js
+++ b/sites/sessions.hub.heart.org/config/gam.js
@@ -9,6 +9,7 @@ config
     { name: 'rail2', templateName: 'rail', path: 'rail2' },
     { name: 'rail3', templateName: 'rail', path: 'rail3' },
     { name: 'load-more', templateName: 'load-more', path: 'load-more' },
+    { name: 'reskin', path: 'reskin' },
   ]);
 
 module.exports = config;

--- a/sites/sessions.hub.heart.org/config/navigation.js
+++ b/sites/sessions.hub.heart.org/config/navigation.js
@@ -15,6 +15,7 @@ const topics = [
   { href: '/late-breaking-science', label: 'Late-Breaking Science' },
   { href: '/daily-coverage', label: 'Daily Coverage' },
   { href: '/industry-highlights', label: 'Industry Highlights' },
+  { href: '/featured-exhibitors', label: 'Featured Exhibitors' },
   { href: 'https://eventpilotadmin.com/web/planner.php?id=AHA21', label: 'Program', target: '_blank' },
   { href: '/previews', label: 'Previews' },
 ];

--- a/sites/sessions.hub.heart.org/config/site.js
+++ b/sites/sessions.hub.heart.org/config/site.js
@@ -57,4 +57,5 @@ module.exports = {
   },
   ahaFooter: true,
   noticePushdown: true,
+  featuredExhibitors: true,
 };

--- a/sites/sessions.hub.heart.org/server/routes/website-section/index.js
+++ b/sites/sessions.hub.heart.org/server/routes/website-section/index.js
@@ -1,8 +1,14 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/website-section-page');
 const section = require('@ascend-media/package-global/templates/website-section');
+const exhibitors = require('../../templates/website-section/featured-exhibitors');
 
 module.exports = (app) => {
+  app.get('/:alias(featured-exhibitors)', withWebsiteSection({
+    template: exhibitors,
+    queryFragment,
+  }));
+
   app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
     template: section,
     queryFragment,

--- a/sites/sessions.hub.heart.org/server/templates/website-section/featured-exhibitors.marko
+++ b/sites/sessions.hub.heart.org/server/templates/website-section/featured-exhibitors.marko
@@ -1,0 +1,24 @@
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+
+$ const { GAM } = out.global;
+
+$ const {
+  id,
+  alias,
+  name,
+  pageNode,
+} = input;
+
+<marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+  <@head>
+    <marko-web-gtm-website-section-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-website-section-context>
+  </@head>
+
+  <@page>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <global-featured-exhibitors-block section-alias=alias />
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-website-section-page-layout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,7 +2610,7 @@
     http-errors "^1.8.0"
     node-fetch "^2.6.1"
 
-"@parameter1/base-cms-marko-web-reveal-ad@^2.75.1":
+"@parameter1/base-cms-marko-web-reveal-ad@^2.45.0", "@parameter1/base-cms-marko-web-reveal-ad@^2.75.1":
   version "2.75.1"
   resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-reveal-ad/-/base-cms-marko-web-reveal-ad-2.75.1.tgz#6df390011c4d6d109d86645ccca5d768a9ec0f46"
   integrity sha512-wcT2R0HE84QZs6x18j5Fi0GgPL0wrX9McskGPnsEUveCwI22FTMY045N2BZS/+9MDy52FE0L9UBk173Yeg4+Mw==


### PR DESCRIPTION
![Featured-Exhibitors-Sessions](https://user-images.githubusercontent.com/46794001/179574405-cfa88145-f532-433f-bd7e-b907e074cc4d.png)
![Featured-Company-Sessions](https://user-images.githubusercontent.com/46794001/179574416-eace15f3-6df8-464f-86b9-af2583c06ccc.png)

Setting as draft as we still need to add the reskin add to Sessions GAM configuration.

EDIT: No longer set as draft as ad unit has been added to GAM configuration (on the GAM side).