### PR TITLE
Implement Native-X Hero Block

### DIFF
--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -70,5 +70,8 @@
   },
   "<global-featured-exhibitors-block>": {
     "template": "./featured-exhibitors.marko"
+  },
+  "<global-native-x-hero-block>": {
+    "template": "./native-x-hero.marko"
   }
 }

--- a/packages/global/components/blocks/native-x-hero.marko
+++ b/packages/global/components/blocks/native-x-hero.marko
@@ -1,0 +1,16 @@
+$ const { aliases } = input;
+
+<default-theme-hero-flow nodes=input.nodes>
+  <@hero|{ node }|>
+    <global-content-hero-node node=node image-width=630 title-modifiers=["large"] />
+  </@hero>
+  <@list|{ nodes }|>
+    <global-native-x-list-block
+      placement-name="default"
+      aliases=aliases
+      limit=4
+      collapsible=true
+      display-header=false
+    />
+  </@list>
+</default-theme-hero-flow>

--- a/packages/global/components/blocks/native-x-list.marko
+++ b/packages/global/components/blocks/native-x-list.marko
@@ -18,6 +18,7 @@ $ const withTeaser = defaultValue(input.withTeaser, false);
 $ const innerJustified = defaultValue(input.innerJustified, false);
 $ const displayImage = defaultValue(input.displayImage, true);
 $ const title = defaultValue(input.title, "Interesting Stories")
+$ const displayHeader = defaultValue(input.displayHeader, true);
 
 <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: limit }>
   $ const nodes = ads.filter(ad => ad.hasCampaign);
@@ -31,7 +32,9 @@ $ const title = defaultValue(input.title, "Interesting Stories")
       ...input.list
     >
 
-      <@header>${title}</@header>
+      <if(displayHeader)>
+        <@header>${title}</@header>
+      </if>
       <@nodes nodes=nodes>
         <@slot|{ node: ad, index }|>
           $ const node = convertAdToContent(ad, { sectionName: `Sponsored by ${ad.campaign.advertiserName}` });

--- a/packages/global/templates/website-section/index.marko
+++ b/packages/global/templates/website-section/index.marko
@@ -5,7 +5,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import websiteSectionContentLoader from "../../loaders/website-section-content";
 import queryFragment from "../../graphql/fragments/content-list";
 
-$ const { GAM, apollo } = out.global;
+$ const { GAM, apollo, site } = out.global;
 
 $ const {
   id,
@@ -36,6 +36,8 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   withStandardQuery: true,
 });
+
+$ const useNativeXHeroBlock = site.getAsArray("nativeXHeroSections").includes(alias);
 
 <marko-web-resolve|{ resolved: sectionContent }| promise=promise>
   $ const { featured, standard } = sectionContent;
@@ -68,7 +70,12 @@ $ const promise = websiteSectionContentLoader(apollo, {
         />
       </@above-page>
       <@page>
-        <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
+        <if(useNativeXHeroBlock)>
+          <global-native-x-hero-block nodes=getAsArray(featured, "nodes") aliases=aliases />
+        </if>
+        <else>
+          <global-standard-hero-block nodes=getAsArray(featured, "nodes") />-
+        </else>
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 5) cols=3 ad-index=1 ad-name="rail1" ad-modifiers=["paid"]>
           <@native-x index=2 name="default" aliases=[section.alias] />
         </global-content-card-deck-flow>

--- a/sites/sessions.hub.heart.org/config/site.js
+++ b/sites/sessions.hub.heart.org/config/site.js
@@ -63,4 +63,5 @@ module.exports = {
   ahaFooter: true,
   noticePushdown: true,
   featuredExhibitors: true,
+  nativeXHeroSections: ['industry-highlights'],
 };


### PR DESCRIPTION
This replaces the usual content list with the "Interesting Stories" Native-X list instead and removing the "Interesting Stories" header, making it essentially blend exactly in as if it were a regular content list.

This is enabled for the Industry Highlights section for Sessions, currently this uses the default Native-X channel but could be configured to use a channel specific one if that need arises in the future.

Native-X Hero Block:
![industry-highlights-native-x-hero](https://user-images.githubusercontent.com/46794001/182642177-88eea42b-8537-4653-ae41-5e5f55e8e5be.png)

No Native-X Hero Block:
![no-native-x-hero-block](https://user-images.githubusercontent.com/46794001/182642228-cdf04b83-3332-44a5-91ab-b295cd9d8565.png)

