### PR TITLE
Update IMEX Homepage and Content Page Layouts

### DIFF
--- a/packages/daily/components/blocks/marko.json
+++ b/packages/daily/components/blocks/marko.json
@@ -86,5 +86,8 @@
   },
   "<daily-global-right-rail-block>": {
     "template": "./global-right-rail.marko"
+  },
+  "<daily-native-x-list-block>": {
+    "template": "./native-x-list.marko"
   }
 }

--- a/packages/daily/components/blocks/native-x-list.marko
+++ b/packages/daily/components/blocks/native-x-list.marko
@@ -1,0 +1,57 @@
+import { getAsObject, get } from "@parameter1/base-cms-object-path";
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+import convertAdToContent from "@parameter1/base-cms-marko-web-native-x/utils/convert-ad-to-content";
+
+$ const { nativeX: nxConfig } = out.global;
+$ const limit = defaultValue(input.limit, 3);
+$ const placementName = defaultValue(input.placementName, "default");
+$ const aliases = defaultValue(input.aliases, []);
+
+$ const modifiers = input.modifiers || [];
+$ modifiers.push("native-x-list");
+$ const uri = nxConfig.getUri();
+$ const placement = nxConfig.getPlacement({ name: placementName, aliases });
+
+$ const linkHeader = defaultValue(input.linkHeader, true);
+$ const imagePosition = defaultValue(input.imagePosition, "right");
+$ const withTeaser = defaultValue(input.withTeaser, false);
+$ const innerJustified = defaultValue(input.innerJustified, false);
+$ const displayImage = defaultValue(input.displayImage, true);
+$ const title = defaultValue(input.title, "Interesting Stories")
+$ const displayHeader = defaultValue(input.displayHeader, true);
+
+<marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: limit }>
+  $ const nodes = ads.filter(ad => ad.hasCampaign);
+
+  <if(nodes.length)>
+    <marko-web-node-list
+      inner-justified=innerJustified
+      flush-x=false
+      flush-y=false
+      modifiers=modifiers
+      ...input.list
+    >
+
+      <if(displayHeader)>
+        <@header>${title}</@header>
+      </if>
+      <@nodes nodes=nodes>
+        <@slot|{ node: ad, index }|>
+          $ const node = convertAdToContent(ad, { sectionName: `Sponsored by ${ad.campaign.advertiserName}` });
+          <daily-content-list-node
+            image-position=imagePosition
+            card=false
+            flush=true
+            modifiers=modifiers
+            node=node
+            with-section=true
+            with-teaser=false
+            with-dates=false
+            attrs=ad.attributes.container
+            link-attrs=ad.attributes.link
+          />
+        </@slot>
+      </@nodes>
+    </marko-web-node-list>
+  </if>
+</marko-web-native-x-fetch-elements>

--- a/sites/imex.ascendmedia.com/server/components/blocks/global-right-rail.marko
+++ b/sites/imex.ascendmedia.com/server/components/blocks/global-right-rail.marko
@@ -1,15 +1,11 @@
 
 <marko-web-gam-display-ad id="gpt-ad-rail1" />
 
-<a
-  class="twitter-timeline btn btn-primary btn-block"
-  data-height="650"
-  data-theme="light"
-  href="https://twitter.com/IMEX_Group?ref_src=twsrc%5Etfw"
-  target="_blank"
->
-  Tweets by IMEX Group
-</a>
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<daily-native-x-list-block
+  placement-name="default"
+  aliases=input.aliases
+  limit=6
+  collapsible=true
+/>
 
 <marko-web-gam-display-ad id="gpt-ad-rail2" class="mt-block-lg" />

--- a/sites/imex.ascendmedia.com/server/templates/content/index.marko
+++ b/sites/imex.ascendmedia.com/server/templates/content/index.marko
@@ -216,4 +216,29 @@ $ const displayCompanyHeader = (content) => {
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
+  <@below-page>
+    <div class="node-list__header--content-load-more">
+      <div class="node-list__header">More Content</div>
+    </div>
+    <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection")
+      $ const aliases = hierarchyAliases(section);
+      $ const loadMoreParams = {
+        sectionId: section.id,
+        optionName: ["Standard"],
+        excludeContentIds: [id],
+        limit: 12,
+      };
+      <marko-web-load-more
+        component-name="daily-content-card-deck-flow"
+        component-input={ aliases, cols: 3, withTeaser: false }
+        fragment-name="daily-content-list"
+        query-name="website-scheduled-content"
+        query-params=loadMoreParams
+        max-pages=3
+        page-input={ for: "content", id }
+        attrs={ "aria-label": "load-more", "role": "main" }
+      />
+    </marko-web-resolve-page>
+  </@below-page>
 </marko-web-content-page-layout>

--- a/sites/imex.ascendmedia.com/server/templates/index.marko
+++ b/sites/imex.ascendmedia.com/server/templates/index.marko
@@ -47,13 +47,11 @@ $ const adSlots = ({ aliases }) => ({
         </div>
 
         <div class="col-lg-4 mb-block-lg page-rail">
-          $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
           <daily-native-x-list-block
             placement-name="default"
             aliases=aliases
             limit=6
             collapsible=true
-            title=nativeXBlockTitle
           />
           <marko-web-gam-display-ad id="gpt-ad-rail2" class="mt-block-lg" />
           <a

--- a/sites/imex.ascendmedia.com/server/templates/index.marko
+++ b/sites/imex.ascendmedia.com/server/templates/index.marko
@@ -89,4 +89,23 @@ $ const adSlots = ({ aliases }) => ({
 
     </marko-web-resolve-page>
   </@page>
+  <@below-page>
+    <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
+      $ const loadMoreParams = {
+        sectionAlias: 'home',
+        optionName: ["Standard"],
+        limit: 12,
+      };
+      <marko-web-load-more
+        component-name="daily-content-card-deck-flow"
+        component-input={ cols: 3, withTeaser: false }
+        fragment-name="daily-content-list"
+        query-name="website-scheduled-content"
+        query-params=loadMoreParams
+        max-pages=3
+        page-input={ for: "content", id }
+        attrs={ "aria-label": "load-more", "role": "main" }
+      />
+    </marko-web-resolve-page>
+  </@below-page>
 </marko-web-website-section-page-layout>

--- a/sites/imex.ascendmedia.com/server/templates/index.marko
+++ b/sites/imex.ascendmedia.com/server/templates/index.marko
@@ -1,6 +1,6 @@
 import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
 
-$ const { GAM, nativeX } = out.global;
+$ const { GAM, nativeX, site } = out.global;
 
 $ const {
   id,
@@ -41,12 +41,21 @@ $ const adSlots = ({ aliases }) => ({
             <@native-x index=2 name="default" aliases=["daily-news"] />
           </daily-content-featured-block>
 
-          <daily-section-list-block section-alias="industry-insights" inner-justified=false with-teaser=true limit=2>
+          <daily-section-list-block section-alias="industry-insights" inner-justified=false with-teaser=true limit=4>
             <@image width="125" />
           </daily-section-list-block>
         </div>
 
         <div class="col-lg-4 mb-block-lg page-rail">
+          $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
+          <daily-native-x-list-block
+            placement-name="default"
+            aliases=aliases
+            limit=6
+            collapsible=true
+            title=nativeXBlockTitle
+          />
+          <marko-web-gam-display-ad id="gpt-ad-rail2" class="mt-block-lg" />
           <a
             class="twitter-timeline btn btn-primary btn-block"
             data-height="650"
@@ -57,8 +66,6 @@ $ const adSlots = ({ aliases }) => ({
             Tweets by IMEX Group
           </a>
           <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-          <marko-web-gam-display-ad id="gpt-ad-rail2" class="mt-block-lg" />
         </div>
       </div>
 
@@ -81,8 +88,6 @@ $ const adSlots = ({ aliases }) => ({
           </daily-section-list-block>
         </div>
       </div>
-
-      <daily-featured-exhibitors-block section-alias="featured-exhibitors" />
 
     </marko-web-resolve-page>
   </@page>

--- a/sites/imex.ascendmedia.com/server/templates/index.marko
+++ b/sites/imex.ascendmedia.com/server/templates/index.marko
@@ -95,6 +95,7 @@ $ const adSlots = ({ aliases }) => ({
         sectionAlias: 'home',
         optionName: ["Standard"],
         limit: 12,
+        skip: 3
       };
       <marko-web-load-more
         component-name="daily-content-card-deck-flow"


### PR DESCRIPTION
Rearranges some blocks in the homepages right rail in order to accommodate an "Interesting Stories" block as well as adding load more to content and the home page. 

![Home-Page-IMEX](https://user-images.githubusercontent.com/46794001/184403172-0303ac89-c7b8-4fc6-98d7-51a39c3c4b8c.png)
![More-Content-IMEX](https://user-images.githubusercontent.com/46794001/184403183-3c54cf59-13db-44d2-99fc-8d759d73ec09.png)
![Load-More-With-Proper-Skip](https://user-images.githubusercontent.com/46794001/184643736-05a766b7-3aec-4739-ba3d-03be41b005e6.png)

