### PR TITLE
Replace ‘#ReSS22’ with ‘Connection Hub’ in nav

### DIFF
--- a/sites/sessions.hub.heart.org/config/navigation.js
+++ b/sites/sessions.hub.heart.org/config/navigation.js
@@ -22,7 +22,7 @@ const topics = [
 
 const secondary = [
   { href: 'https://twitter.com/search?q=%23AHA21&src=typed_query', label: '#AHA22' },
-  { href: '#', label: '#ReSS22' },
+  { href: '#', label: 'Connection Hub' },
   { href: '#', label: 'Virtual Experience Access', target: '_blank' },
   { href: '#', label: 'Sessions Posters', target: '_blank' },
 ];


### PR DESCRIPTION
<img width="1262" alt="Screen Shot 2022-09-06 at 1 00 48 PM" src="https://user-images.githubusercontent.com/64623209/188706812-d7d6ae2e-eb29-47f9-885d-ff8c4ccc8f4f.png">
