### PR TITLE
Update Load More, enable reskin AD for AAD Company Pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -262,6 +262,7 @@ services:
       SITE_ID: 60c7666d46f24a64538b458d
       NATIVE_X_BLOCK: "true"
       RESTRICT_RIGHT_RAIL_DISPLAY: "true"
+      CONTENT_PAGE_LOAD_MORE: "true"
     ports:
       - "9921:80"
       - "19921:19921"

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -227,9 +227,6 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && ["document", "p
   </@page>
   <if(site.get("contentPageLoadMore"))>
     <@below-page>
-      <div class="node-list__header--content-load-more">
-        <div class="node-list__header">More Content</div>
-      </div>
       <marko-web-resolve-page|{ resolved, data: content }| node=pageNode>
         $ const section = resolved.getAsObject("primarySection")
         $ const aliases = hierarchyAliases(section);
@@ -239,16 +236,23 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && ["document", "p
           excludeContentIds: [id],
           limit: 12,
         };
-        <marko-web-load-more
-          component-name="global-content-card-deck-flow"
-          component-input={ aliases, cols: 3, withTeaser: false }
-          fragment-name="global-content-list"
-          query-name="website-scheduled-content"
-          query-params=loadMoreParams
-          max-pages=3
-          page-input={ for: "content", id }
-          attrs={ "aria-label": "load-more", "role": "main" }
-        />
+        $ const aadRules = ["AAD"].includes(site.get("siteAcronym")) && ['press-release'].includes(type);
+        $ const header = ["AAD"].includes(site.get("siteAcronym")) ? `More in ${section.name}` : 'More Content';
+        <if(!aadRules)>
+          <div class="node-list__header--content-load-more">
+            <div class="node-list__header">${header}</div>
+          </div>
+          <marko-web-load-more
+              component-name="global-content-card-deck-flow"
+              component-input={ aliases, cols: 3, withTeaser: false }
+              fragment-name="global-content-list"
+              query-name="website-scheduled-content"
+              query-params=loadMoreParams
+              max-pages=3
+              page-input={ for: "content", id }
+              attrs={ "aria-label": "load-more", "role": "main" }
+          />
+        </if>
       </marko-web-resolve-page>
     </@below-page>
   </if>

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -237,9 +237,9 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && ["document", "p
           limit: 12,
         };
         $ const contentPageLoadMoreSettings = site.get("contentPageLoadMoreSettings");
-        $ const noLoadMore = contentPageLoadMoreSettings && getAsArray(contentPageLoadMoreSettings, 'restrictedOn').includes(type);
-        $ const header = contentPageLoadMoreSettings && get(contentPageLoadMoreSettings, "useSectionForHeader") ? `More in ${section.name}` : 'More Content';
-        <if(!noLoadMore)>
+        $ const enableLoadMore = !getAsArray(contentPageLoadMoreSettings, 'restrictedOn').includes(type);
+        $ const header = get(contentPageLoadMoreSettings, "useSectionForHeader") ? `More in ${section.name}` : 'More Content';
+        <if(enableLoadMore)>
           <div class="node-list__header--content-load-more">
             <div class="node-list__header">${header}</div>
           </div>

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -236,9 +236,10 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && ["document", "p
           excludeContentIds: [id],
           limit: 12,
         };
-        $ const aadRules = ["AAD"].includes(site.get("siteAcronym")) && ['press-release'].includes(type);
-        $ const header = ["AAD"].includes(site.get("siteAcronym")) ? `More in ${section.name}` : 'More Content';
-        <if(!aadRules)>
+        $ const contentPageLoadMoreSettings = site.get("contentPageLoadMoreSettings");
+        $ const noLoadMore = contentPageLoadMoreSettings && getAsArray(contentPageLoadMoreSettings, 'restrictedOn').includes(type);
+        $ const header = contentPageLoadMoreSettings && get(contentPageLoadMoreSettings, "useSectionForHeader") ? `More in ${section.name}` : 'More Content';
+        <if(!noLoadMore)>
           <div class="node-list__header--content-load-more">
             <div class="node-list__header">${header}</div>
           </div>

--- a/sites/aadmeetingnews.org/config/gam.js
+++ b/sites/aadmeetingnews.org/config/gam.js
@@ -9,6 +9,7 @@ config
     { name: 'rail2', templateName: 'rail', path: 'rail2' },
     { name: 'rail3', templateName: 'rail', path: 'rail3' },
     { name: 'load-more', templateName: 'load-more', path: 'load-more' },
+    { name: 'reskin', path: 'reskin' },
   ]);
 
 module.exports = config;

--- a/sites/aadmeetingnews.org/config/site.js
+++ b/sites/aadmeetingnews.org/config/site.js
@@ -7,7 +7,10 @@ module.exports = {
   nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
-  siteAcronym: 'AAD',
+  contentPageLoadMoreSettings: {
+    restrictedOn: ['press-release'],
+    useSectionForHeader: true,
+  },
   logos,
   navigation,
   gam,

--- a/sites/aadmeetingnews.org/config/site.js
+++ b/sites/aadmeetingnews.org/config/site.js
@@ -7,6 +7,7 @@ module.exports = {
   nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
+  siteAcronym: 'AAD',
   logos,
   navigation,
   gam,


### PR DESCRIPTION
AAD Press Release Behavior:
![AAD-PRESS-RELEASE-1](https://user-images.githubusercontent.com/46794001/193304488-804735ed-1596-4cd4-8798-2b9457ea1ad5.png)
![AAD-Press-Release](https://user-images.githubusercontent.com/46794001/193304549-3cf5eef0-d443-4451-9ab5-bc924dc75e30.png)

AAD Article Behavior:
![AAD-Article](https://user-images.githubusercontent.com/46794001/193304618-94ebf126-1b45-4a66-a359-455316fbe8fb.png)


AUA Press Release Behavior (To show restriction logic isn't applied elsewhere):
![Press-Release-AUA](https://user-images.githubusercontent.com/46794001/193304736-c93b416e-afac-42f0-9dc8-b169e60afb0d.png)


NOTE: At time of PR I have no added the Reskin ad unit to the AAD GAM configuration on the GAM side.