### PR TITLE
Correct Native-X-Story CSS to resize image on mobile Safari

### DIFF
--- a/packages/daily/scss/components/_native-x-story.scss
+++ b/packages/daily/scss/components/_native-x-story.scss
@@ -42,10 +42,12 @@
       font-size: 20px;
       @media (min-width: $marko-web-document-container-max-width) {
         font-size: 40px;
+        background: url("") center/cover no-repeat fixed;
       }
       font-weight: $font-weight-bold;
       color: $white;
       text-align: center;
+      background: url("") center/cover no-repeat scroll;
       h1 {
         font-size: 30px;
         @media (min-width: $marko-web-document-container-max-width) {

--- a/packages/daily/templates/content/native-x-story.marko
+++ b/packages/daily/templates/content/native-x-story.marko
@@ -19,7 +19,7 @@ $ const src = buildImgixUrl(content.primaryImage.src, imageOptions);
 
     <marko-web-page-wrapper>
       <@section|{ blockName }| modifiers=["native-x-story-header"]>
-        <div class="content-page-primary-image" style=`width: 100%; height: ${imageOptions.h}px; background:url(${src}) center/cover no-repeat fixed;`>
+        <div class="content-page-primary-image" style=`width: 100%; height: ${imageOptions.h}px; background-image:url(${src})`>
         <div class="content-page-header">
           <marko-web-content-name tag="h1" block-name=blockName obj=content />
           <presented-by advertiser=story.advertiser />

--- a/packages/global/scss/components/_native-x-story.scss
+++ b/packages/global/scss/components/_native-x-story.scss
@@ -42,10 +42,12 @@
       font-size: 20px;
       @media (min-width: $marko-web-document-container-max-width) {
         font-size: 40px;
+        background: url("") center/cover no-repeat fixed;
       }
       font-weight: $font-weight-bold;
       color: $white;
       text-align: center;
+      background: url("") center/cover no-repeat scroll;
       h1 {
         font-size: 30px;
         @media (min-width: $marko-web-document-container-max-width) {

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -19,7 +19,7 @@ $ const src = buildImgixUrl(content.primaryImage.src, imageOptions);
 
     <marko-web-page-wrapper>
       <@section|{ blockName }| modifiers=["native-x-story-header"]>
-        <div class="content-page-primary-image" style=`width: 100%; height: ${imageOptions.h}px; background:url(${src}) center/cover no-repeat fixed;`>
+        <div class="content-page-primary-image" style=`width: 100%; height: ${imageOptions.h}px; background-image:url(${src})`>
         <div class="content-page-header">
           <marko-web-content-name tag="h1" block-name=blockName obj=content />
           <presented-by advertiser=story.advertiser />


### PR DESCRIPTION
See https://github.com/parameter1/ascend-media-websites/pull/383 for what this looks like, ultimately this is a potential correction to the images not resizing on mobile Safair which is based on the conversation here:

https://stackoverflow.com/questions/36189324/header-image-not-resizing-on-mobile-safari-remains-completely-zoomed-out

Due to the nature of image resizing on mobile versions of Safari it causes issues when using ```background-attachment: fixed``` and needs to be changed to ```backround-attachment: scroll``` as a result. This will stop the image from doing scroll over on "mobile" (screens less than 1150px wide), (a.k.a the image "falling away" and the text somewhat still scrolling down into it). If this ultimately doesn't correct the image resizing on Safari however, it can simply be reverted and will operate the same (except mobile Safari)