### PR TITLE
Move 2nd 300x350 to middle of second vs last in third row

### DIFF
--- a/packages/bulletin/components/layouts/magazine/issue.marko
+++ b/packages/bulletin/components/layouts/magazine/issue.marko
@@ -67,7 +67,7 @@ $ const { issue } = input;
         <@slot|{ node, index }|>
           <daily-content-card-node node=node with-attribution=false with-section=false with-dates=false with-teaser=true />
         </@slot>
-        <@slot position="after" index=7>
+        <@slot position="after" index=3>
           <marko-web-gam-display-ad id="gpt-ad-rail2" modifiers=["in-card"] />
         </@slot>
       </default-theme-card-deck-flow>


### PR DESCRIPTION
Move the second 300x250 ad from the last item in the third row to the second slot in the second row.  So it will display the ad like it does on the first 8 items.

<img width="549" alt="Screen Shot 2022-10-11 at 4 09 10 PM" src="https://user-images.githubusercontent.com/3845869/195198851-3e26d19b-62ea-4349-88d4-e77e0b4f7d14.png">
