### PR TITLE
Move 300x250 ad up 1 row on content pages Bulletin

### DIFF
--- a/packages/bulletin/templates/content/index.marko
+++ b/packages/bulletin/templates/content/index.marko
@@ -110,7 +110,7 @@ $ const adSlots = ({ aliases }) => ({
                 <@slot|{ node, index }|>
                   <daily-content-card-node node=node with-section=false with-dates=false with-attribution=false />
                 </@slot>
-                <@slot position="after" index=7>
+                <@slot position="after" index=3>
                   <marko-web-gam-display-ad id="gpt-ad-rail2" modifiers=["in-card"] />
                 </@slot>
               </default-theme-card-deck-flow>


### PR DESCRIPTION
Repeats https://github.com/parameter1/ascend-media-websites/pull/397 for the content pages as well.

![300x250-again](https://user-images.githubusercontent.com/46794001/195363778-2fc62fa1-2755-4109-a8d1-f302b2eead1b.png)
