### PR TITLE
Template and Routing for ```/classifieds``` Bulletin

### DIFF
--- a/packages/bulletin/components/marko.json
+++ b/packages/bulletin/components/marko.json
@@ -3,7 +3,8 @@
     "./blocks/marko.json",
     "./flows/marko.json",
     "./layouts/marko.json",
-    "./nodes/marko.json"
+    "./nodes/marko.json",
+    "./page/marko.json"
   ],
   "<bulletin-document>": {
     "template": "./document.marko",

--- a/packages/bulletin/components/page/classifieds.marko
+++ b/packages/bulletin/components/page/classifieds.marko
@@ -1,0 +1,24 @@
+$ const {
+  type = "classifieds",
+  title,
+  description,
+  head,
+  page,
+  abovePage,
+  belowPage,
+  ...rest
+} = input;
+$ const { document } = out.global;
+
+<${document} ...rest>
+  <@head>
+    <marko-web-default-page-metadata title=title description=description />
+    <${head} />
+  </@head>
+  <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
+  <@container abovePage=abovePage belowPage=belowPage modifiers=["classifieds"]>
+    <@page for=type>
+      <${page} />
+    </@page>
+  </@container>
+</>

--- a/packages/bulletin/components/page/marko.json
+++ b/packages/bulletin/components/page/marko.json
@@ -1,0 +1,5 @@
+{
+  "<bulletin-classifieds-page>": {
+    "template": "./classifieds.marko"
+  }
+}

--- a/packages/daily/components/blocks/content-hero.marko
+++ b/packages/daily/components/blocks/content-hero.marko
@@ -1,4 +1,4 @@
-import { getAsObject, get } from "@parameter1/base-cms-object-path";
+import { getAsObject, get, getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/content-hero";
 
 $ const { sectionId, limit } = input;
@@ -13,6 +13,8 @@ $ const queryParams = {
   ...getAsObject(input, "queryParams"),
   sectionId,
 };
+
+$ const adSlots = getAsArray(input.adSlots).length ? getAsArray(input.adSlots) : ["gpt-ad-column1", "gpt-ad-rail1"]
 
 <marko-web-query|{ nodes }| name="website-optioned-content" params=queryParams>
   <default-theme-hero-flow nodes=nodes>
@@ -48,10 +50,10 @@ $ const queryParams = {
           </@body>
         </@image>
       </marko-web-node>
-      <marko-web-gam-display-ad id="gpt-ad-column1" modifiers=["top-of-page", "max-width-728", "center"] />
+      <marko-web-gam-display-ad id=adSlots[0] modifiers=["top-of-page", "max-width-728", "center"] />
     </@hero>
     <@list|{ nodes }|>
-      <marko-web-gam-display-ad id="gpt-ad-rail1" />
+      <marko-web-gam-display-ad id=adSlots[1] />
       <if(nodes.length)>
         <for|content, index| of=nodes>
           $ const primaryImage = getAsObject(content, "primaryImage");

--- a/packages/daily/components/blocks/marko.json
+++ b/packages/daily/components/blocks/marko.json
@@ -107,5 +107,8 @@
   },
   "<daily-exhibitors-banner-block>": {
     "template": "./exhibitors-banner.marko"
+  },
+  "<daily-native-x-hero-card-block>": {
+    "template": "./native-x-hero-card.marko"
   }
 }

--- a/packages/daily/components/blocks/native-x-hero-card.marko
+++ b/packages/daily/components/blocks/native-x-hero-card.marko
@@ -1,0 +1,55 @@
+import { getAsObject, get } from "@parameter1/base-cms-object-path";
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+import convertAdToContent from "@parameter1/base-cms-marko-web-native-x/utils/convert-ad-to-content";
+
+$ const { nativeX: nxConfig } = out.global;
+$ const placementName = defaultValue(input.placementName, "default");
+$ const aliases = defaultValue(input.aliases, []);
+
+$ const modifiers = input.modifiers || [];
+$ modifiers.push("native-x-list");
+$ const uri = nxConfig.getUri();
+$ const placement = nxConfig.getPlacement({ name: placementName, aliases });
+
+<marko-web-native-x-fetch-elements|{ ads }| uri=uri id=placement.id opts={ n: 1 }>
+  $ const nodes = ads.filter(ad => ad.hasCampaign);
+  <if(nodes.length)>
+    $ const ad = nodes[0]
+    $ const content = { 
+      ...convertAdToContent(ad, { sectionName: `Sponsored by ${ad.campaign.advertiserName}` }),
+      attributes: {
+        ...ad.attributes
+      }
+    }
+    $ const primaryImage = getAsObject(content, "primaryImage");
+    <marko-web-node
+      type=`${content.type}-content`
+      image-position="top"
+      card=true
+      flush=true
+      full-height=false
+      modifiers=["hero"]
+    >
+      <@header>
+        <@left|{ blockName }|>
+          <marko-web-content-short-name 
+            obj=content
+            block-name=blockName
+            link={ href: content.siteContext.path, attrs: getAsObject(content, "attributes.link")}
+          />
+        </@left>
+      </@header>
+        <@image
+          ar="16:9"
+          width="630"
+          fluid=true
+          use-placeholder=false
+          src=primaryImage.src
+          alt=primaryImage.alt
+          is-logo=primaryImage.isLogo
+          link={ href: content.siteContext.path, attrs: getAsObject(content, "attributes.link") }
+        >
+        </@image>
+    </marko-web-node>
+  </if>
+</marko-web-native-x-fetch-elements>

--- a/packages/daily/components/blocks/section-list.marko
+++ b/packages/daily/components/blocks/section-list.marko
@@ -12,6 +12,7 @@ $ const imagePosition = defaultValue(input.imagePosition, "left");
 $ const withTeaser = defaultValue(input.withTeaser, false);
 $ const innerJustified = defaultValue(input.innerJustified, true);
 $ const withSection = defaultValue(input.withSection, true);
+$ const imageWidth = defaultValue(input.imageWidth, "90");
 
 $ const queryParams = {
   limit: input.limit || 4,
@@ -57,7 +58,7 @@ $ const queryParams = {
           >
             <@image
               ar="1:1"
-              width="90"
+              width=imageWidth
               use-placeholder=false
               src=primaryImage.src
               alt=primaryImage.alt

--- a/packages/daily/components/blocks/section-list.marko
+++ b/packages/daily/components/blocks/section-list.marko
@@ -11,6 +11,7 @@ $ const linkHeader = defaultValue(input.linkHeader, true);
 $ const imagePosition = defaultValue(input.imagePosition, "left");
 $ const withTeaser = defaultValue(input.withTeaser, false);
 $ const innerJustified = defaultValue(input.innerJustified, true);
+$ const withSection = defaultValue(input.withSection, true);
 
 $ const queryParams = {
   limit: input.limit || 4,
@@ -65,11 +66,13 @@ $ const queryParams = {
               ...input.image
             />
             <@body>
-              <@header>
-                <@left>
-                  <marko-web-website-section-name obj=primarySection link=true />
-                </@left>
-              </@header>
+              <if(withSection)>
+                <@header>
+                  <@left>
+                    <marko-web-website-section-name obj=primarySection link=true />
+                  </@left>
+                </@header>
+                </if>
               <@title tag="h5">
                 <marko-web-content-short-name tag=null obj=nxNode link={ attrs: linkAttrs } />
               </@title>

--- a/sites/bulletin.entnet.org/config/native-x.js
+++ b/sites/bulletin.entnet.org/config/native-x.js
@@ -1,0 +1,7 @@
+module.exports = {
+  placements: {
+    default: '634d704a311875000158941f',
+    employment: '634d707ae058a900017a0a1c',
+    'courses-meetings': '634d70a1e058a900017a0ab3',
+  },
+};

--- a/sites/bulletin.entnet.org/config/site.js
+++ b/sites/bulletin.entnet.org/config/site.js
@@ -1,11 +1,13 @@
 const navigation = require('./navigation');
 const gam = require('./gam');
 const logos = require('./logos');
+const nativeX = require('./native-x');
 
 module.exports = {
   logos,
   navigation,
   gam,
+  nativeX,
   company: 'American Academy of Otolaryngology–Head and Neck Surgery',
   socialMediaLinks: [],
   gtm: {

--- a/sites/bulletin.entnet.org/server/routes/classifieds.js
+++ b/sites/bulletin.entnet.org/server/routes/classifieds.js
@@ -1,0 +1,10 @@
+const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
+const queryFragment = require('@ascend-media/package-daily/graphql/fragments/website-section-page');
+const classifieds = require('../templates/website-section/classifieds');
+
+module.exports = (app) => {
+  app.get('/:alias(classifieds)', withWebsiteSection({
+    template: classifieds,
+    queryFragment,
+  }));
+};

--- a/sites/bulletin.entnet.org/server/routes/index.js
+++ b/sites/bulletin.entnet.org/server/routes/index.js
@@ -2,10 +2,14 @@ const home = require('./home');
 const content = require('./content');
 const magazine = require('./magazine');
 const search = require('./search');
+const classifieds = require('./classifieds');
 
 module.exports = (app) => {
   // Homepage
   home(app);
+
+  // Classifieds
+  classifieds(app);
 
   // Search Pages
   search(app);

--- a/sites/bulletin.entnet.org/server/styles/index.scss
+++ b/sites/bulletin.entnet.org/server/styles/index.scss
@@ -39,6 +39,13 @@ $theme-card-header-background-color: #fff;
       font-size: 14px;
     }
   }
+  &--text-ad-content-type {
+    .node {
+      &__header {
+        background-color: $theme-card-header-color;
+      }
+    }
+  }
 }
 
 .page-rail {
@@ -182,7 +189,7 @@ $theme-card-header-background-color: #fff;
   }
 }
 
-.document-container {
+/* .document-container {
   &--classifieds {
     @if $marko-web-document-container-max-width {
       @media (min-width: $marko-web-document-container-max-width) {
@@ -192,4 +199,4 @@ $theme-card-header-background-color: #fff;
       }
     }
   }
-}
+} */

--- a/sites/bulletin.entnet.org/server/styles/index.scss
+++ b/sites/bulletin.entnet.org/server/styles/index.scss
@@ -181,3 +181,15 @@ $theme-card-header-background-color: #fff;
     }
   }
 }
+
+.document-container {
+  &--classifieds {
+    @if $marko-web-document-container-max-width {
+      @media (min-width: $marko-web-document-container-max-width) {
+        max-width: 100%;
+        padding-right: 0;
+        padding-left: 0;
+      }
+    }
+  }
+}

--- a/sites/bulletin.entnet.org/server/styles/index.scss
+++ b/sites/bulletin.entnet.org/server/styles/index.scss
@@ -173,7 +173,7 @@ $theme-card-header-background-color: #fff;
   &--classifieds {
     .node-list {
       &__header {
-        background-color: $primary-color;
+        background-color: $theme-card-header-color;
         a {
           color: $white;
         }

--- a/sites/bulletin.entnet.org/server/styles/index.scss
+++ b/sites/bulletin.entnet.org/server/styles/index.scss
@@ -168,3 +168,16 @@ $theme-card-header-background-color: #fff;
     }
   }
 }
+
+.node-list {
+  &--classifieds {
+    .node-list {
+      &__header {
+        background-color: $primary-color;
+        a {
+          color: $white;
+        }
+      }
+    }
+  }
+}

--- a/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
+++ b/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
@@ -12,7 +12,7 @@ $ const adSlots = ({ aliases }) => ({
   "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
 });
 
-<marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+<bulletin-classifieds-page id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
   <@head>
     <marko-web-gtm-website-section-context|{ context }| alias=alias>
       <marko-web-gtm-push data=context />
@@ -27,19 +27,26 @@ $ const adSlots = ({ aliases }) => ({
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page", "max-width-970", "center"] />
 
-      <daily-content-hero-block section-id=id ad-slots=["gpt-ad-lb2", "gpt-ad-rail1"] />
-
       <div class="row">
         <div class="col-lg-6 mb-block-lg">
-          <daily-section-list-block section-alias="classifieds/employment" limit=10 class='node-list--classifieds' />
+          <daily-section-list-block 
+            section-alias="classifieds/employment" 
+            limit=10
+            class="node-list--classifieds"
+            with-section=false
+          />
         </div>
 
         <div class="col-lg-6 mb-block-lg">
-          <daily-section-list-block section-alias="classifieds/courses-meetings" limit=10 class='node-list--classifieds' />
+          <daily-section-list-block 
+            section-alias="classifieds/courses-meetings" 
+            limit=10
+            class="node-list--classifieds"
+            with-section=false
+          />
         </div>
       </div>
 
     </marko-web-resolve-page>
   </@page>
-
-</marko-web-website-section-page-layout>
+</bulletin-classifieds-page>

--- a/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
+++ b/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
@@ -26,27 +26,52 @@ $ const adSlots = ({ aliases }) => ({
   <@page>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page", "max-width-970", "center"] />
-
-      <div class="row">
-        <div class="col-lg-6 mb-block-lg">
-          <daily-section-list-block 
-            section-alias="classifieds/employment" 
-            limit=10
-            class="node-list--classifieds"
-            with-section=false
-          />
-        </div>
-
-        <div class="col-lg-6 mb-block-lg">
-          <daily-section-list-block 
-            section-alias="classifieds/courses-meetings" 
-            limit=10
-            class="node-list--classifieds"
-            with-section=false
-          />
-        </div>
-      </div>
-
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col-lg-6 mb-block-lg">
+              <div class="row">
+                <div class="col-lg-12 mb-block-lg">
+                  <daily-native-x-hero-card-block 
+                    placement-name="default"
+                    aliases=["employment"]
+                  />
+                </div>
+                <div class="col-lg-12 mb-block-lg">
+                  <daily-section-list-block 
+                    section-alias="classifieds/employment" 
+                    limit=10
+                    class="node-list--classifieds"
+                    with-section=false
+                    with-teaser=true
+                    image-width="180"
+                  />
+                </div>
+              </div>
+            </div>
+            <div class="col-lg-6 mb-block-lg">
+              <div class="row">
+                <div class="col-lg-12 mb-block-lg">
+                  <daily-native-x-hero-card-block 
+                    placement-name="default"
+                    aliases=["courses-meetings"]
+                  />
+                </div>
+                <div class="col-lg-12 mb-block-lg">
+                  <daily-section-list-block 
+                    section-alias="classifieds/courses-meetings" 
+                    limit=10
+                    class="node-list--classifieds"
+                    with-section=false
+                    with-teaser=true
+                    image-width="180"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
 </bulletin-classifieds-page>

--- a/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
+++ b/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
@@ -27,7 +27,7 @@ $ const adSlots = ({ aliases }) => ({
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page", "max-width-970", "center"] />
 
-      <daily-content-hero-block section-id=id />
+      <daily-content-hero-block section-id=id ad-slots=["gpt-ad-lb2", "gpt-ad-rail1"] />
 
       <div class="row">
         <div class="col-lg-6 mb-block-lg">

--- a/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
+++ b/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
@@ -1,0 +1,45 @@
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import contentListFragment from "@ascend-media/package-daily/graphql/fragments/content-list";
+
+$ const { GAM } = out.global;
+
+$ const { id, pageNode, alias, name } = data;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
+  "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
+});
+
+<marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+  <@head>
+    <marko-web-gtm-website-section-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-website-section-context>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-slots slots=adSlots({ aliases }) />
+    </marko-web-resolve-page>
+  </@head>
+
+  <@page>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page", "max-width-970", "center"] />
+
+      <daily-content-hero-block section-id=id />
+
+      <div class="row">
+        <div class="col-lg-6 mb-block-lg">
+          <daily-section-list-block section-alias="classifieds/employment" limit=10 class='node-list--classifieds' />
+        </div>
+
+        <div class="col-lg-6 mb-block-lg">
+          <daily-section-list-block section-alias="classifieds/courses-meetings" limit=10 class='node-list--classifieds' />
+        </div>
+      </div>
+
+    </marko-web-resolve-page>
+  </@page>
+
+</marko-web-website-section-page-layout>


### PR DESCRIPTION
Example of page layout using pre-existing sections content and Native-X ads

![Classifieds-do-over](https://user-images.githubusercontent.com/46794001/196232043-707d9f3c-65f0-426a-a964-72dd10f71874.png)

![Classifieds-Do-Over-2](https://user-images.githubusercontent.com/46794001/196232062-4f20d057-a1b7-4f4b-b435-e0b44c39c629.png)
