### PR TITLE
Remove Sponsored slug from content cards, ASA

### DIFF
--- a/packages/global/components/nodes/content-list.marko
+++ b/packages/global/components/nodes/content-list.marko
@@ -11,7 +11,7 @@ $ const primarySection = getAsObject(content, "primarySection");
 
 $ const withTeaser = defaultValue(input.withTeaser, false);
 $ const withBody = defaultValue(input.withBody, false);
-$ const withSection = defaultValue(input.withSection, true);
+$ const withSection = get(primarySection, 'name') === "Sponsored" ? defaultValue(site.get("showSponsoredSlug"), true) : defaultValue(input.withSection, true);
 $ const withAttribution = defaultValue(input.withAttribution, true);
 $ const withDates = defaultValue(input.withDates, true);
 

--- a/sites/asa.org/config/site.js
+++ b/sites/asa.org/config/site.js
@@ -57,4 +57,5 @@ module.exports = {
     cookieDomain: process.env.NODE_ENV === 'production' ? 'asameetingnewscentral.org' : '',
   },
   useFooterOverride: true,
+  showSponsoredSlug: false,
 };


### PR DESCRIPTION
ASA:
![Sponsored-Is-Gone](https://user-images.githubusercontent.com/46794001/195440492-a6e270f6-ee00-412a-bdbf-767499a2dc80.png)

AUA:
![Sponsored-is-not-gone](https://user-images.githubusercontent.com/46794001/195440499-c11f40e1-c1a6-4955-afa7-501e14a91ce4.png)
