### PR TITLE
Improve support for six stories in "Interesting Stories" block on homepage

### DIFF
--- a/sites/aadmeetingnews.org/server/routes/home.js
+++ b/sites/aadmeetingnews.org/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/website-section-page');
-const home = require('@ascend-media/package-global/templates/website-section/home');
+const home = require('../templates/website-section/home');
 
 module.exports = (app) => {
   app.get('/', withWebsiteSection({

--- a/sites/aadmeetingnews.org/server/templates/website-section/home.marko
+++ b/sites/aadmeetingnews.org/server/templates/website-section/home.marko
@@ -1,0 +1,126 @@
+import { get, getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { isFunction } from "@parameter1/base-cms-utils";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import websiteSectionContentLoader from "@ascend-media/package-global/loaders/website-section-content";
+import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
+
+$ const { GAM, apollo, site } = out.global;
+$ const nativeXBlock = site.get('nativeXBlock');
+
+$ const {
+  id,
+  alias,
+  name,
+  pageNode,
+} = input;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
+  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail3", size:[300, 600],  aliases }),
+});
+
+$ const promise = websiteSectionContentLoader(apollo, {
+  sectionId: id,
+  featuredParams: {
+    optionName: ["Pinned"],
+    limit: 5,
+    requiresImage: true,
+    queryFragment
+  },
+  standardParams: {
+    optionName: ["Standard"],
+    limit: 10,
+    requiresImage: true,
+    queryFragment
+  },
+  withStandardQuery: true,
+});
+
+<marko-web-resolve|{ resolved: sectionContent }| promise=promise>
+  $ const { featured, standard } = sectionContent;
+  <marko-web-resolve|{ resolved: { data: section } }| promise=pageNode.load()>
+    $ const aliases = hierarchyAliases(section);
+    $ const slots = adSlots({ aliases });
+    <marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+      <@head>
+        <marko-web-gtm-website-section-context|{ context }| alias=alias>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-website-section-context>
+        <marko-web-gam-slots slots=slots />
+      </@head>
+
+      <@above-page>
+        <marko-web-gam-display-ad
+          id="gpt-ad-lb1"
+          slots=slots
+          class="mt-block"
+          modifiers=["max-width-970", "margin-auto-x", "center", "paid"]
+        />
+      </@above-page>
+      <@page>
+        <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
+        <div class="row">
+          <div class="col-lg-8">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+              <@native-x index=0 name="default" />
+            </global-content-card-deck-flow>
+          </div>
+          <div class="col-lg-4">
+            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
+            $ const showSectionTitle = site.get('nativeXBlockSlugs');
+            <global-native-x-list-block
+              placement-name="default"
+              aliases=aliases
+              limit=6
+              collapsible=true
+              title=nativeXBlockTitle
+              with-section=showSectionTitle
+            />
+          </div>
+        </div>
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+
+        <div class="row">
+          <div class="col-lg-4 mb-block">
+            <marko-web-gam-display-ad id="gpt-ad-rail3" />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-twitter-widget-block />
+          </div>
+        </div>
+
+        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center", "paid"] />
+
+      </@page>
+
+      <@below-page>
+        <marko-web-resolve-page|{ data: section }| node=pageNode>
+          $ const aliases = hierarchyAliases(section);
+          $ const loadMoreParams = {
+            sectionId: id,
+            optionName: ["Standard"],
+            excludeContentIds: sectionContent.ids,
+            limit: 12,
+          };
+          <marko-web-load-more
+            component-name="global-content-card-deck-flow"
+            component-input={ aliases, cols: 3, withTeaser: false }
+            fragment-name="global-content-list"
+            query-name="website-scheduled-content"
+            query-params=loadMoreParams
+            max-pages=3
+            page-input={ for: "website-section", id }
+            attrs={ "aria-label": "load-more", "role": "main" }
+          />
+        </marko-web-resolve-page>
+      </@below-page>
+
+    </marko-web-website-section-page-layout>
+  </marko-web-resolve>
+</marko-web-resolve>

--- a/sites/asa.org/server/routes/home.js
+++ b/sites/asa.org/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/website-section-page');
-const home = require('@ascend-media/package-global/templates/website-section/home');
+const home = require('../templates/website-section/home');
 
 module.exports = (app) => {
   app.get('/', withWebsiteSection({

--- a/sites/asa.org/server/templates/website-section/home.marko
+++ b/sites/asa.org/server/templates/website-section/home.marko
@@ -1,0 +1,126 @@
+import { get, getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { isFunction } from "@parameter1/base-cms-utils";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import websiteSectionContentLoader from "@ascend-media/package-global/loaders/website-section-content";
+import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
+
+$ const { GAM, apollo, site } = out.global;
+$ const nativeXBlock = site.get('nativeXBlock');
+
+$ const {
+  id,
+  alias,
+  name,
+  pageNode,
+} = input;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
+  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail3", size:[300, 600],  aliases }),
+});
+
+$ const promise = websiteSectionContentLoader(apollo, {
+  sectionId: id,
+  featuredParams: {
+    optionName: ["Pinned"],
+    limit: 5,
+    requiresImage: true,
+    queryFragment
+  },
+  standardParams: {
+    optionName: ["Standard"],
+    limit: 10,
+    requiresImage: true,
+    queryFragment
+  },
+  withStandardQuery: true,
+});
+
+<marko-web-resolve|{ resolved: sectionContent }| promise=promise>
+  $ const { featured, standard } = sectionContent;
+  <marko-web-resolve|{ resolved: { data: section } }| promise=pageNode.load()>
+    $ const aliases = hierarchyAliases(section);
+    $ const slots = adSlots({ aliases });
+    <marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+      <@head>
+        <marko-web-gtm-website-section-context|{ context }| alias=alias>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-website-section-context>
+        <marko-web-gam-slots slots=slots />
+      </@head>
+
+      <@above-page>
+        <marko-web-gam-display-ad
+          id="gpt-ad-lb1"
+          slots=slots
+          class="mt-block"
+          modifiers=["max-width-970", "margin-auto-x", "center", "paid"]
+        />
+      </@above-page>
+      <@page>
+        <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
+        <div class="row">
+          <div class="col-lg-8">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+              <@native-x index=0 name="default" />
+            </global-content-card-deck-flow>
+          </div>
+          <div class="col-lg-4">
+            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
+            $ const showSectionTitle = site.get('nativeXBlockSlugs');
+            <global-native-x-list-block
+              placement-name="default"
+              aliases=aliases
+              limit=6
+              collapsible=true
+              title=nativeXBlockTitle
+              with-section=showSectionTitle
+            />
+          </div>
+        </div>
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+
+        <div class="row">
+          <div class="col-lg-4 mb-block">
+            <marko-web-gam-display-ad id="gpt-ad-rail3" />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-twitter-widget-block />
+          </div>
+        </div>
+
+        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center", "paid"] />
+
+      </@page>
+
+      <@below-page>
+        <marko-web-resolve-page|{ data: section }| node=pageNode>
+          $ const aliases = hierarchyAliases(section);
+          $ const loadMoreParams = {
+            sectionId: id,
+            optionName: ["Standard"],
+            excludeContentIds: sectionContent.ids,
+            limit: 12,
+          };
+          <marko-web-load-more
+            component-name="global-content-card-deck-flow"
+            component-input={ aliases, cols: 3, withTeaser: false }
+            fragment-name="global-content-list"
+            query-name="website-scheduled-content"
+            query-params=loadMoreParams
+            max-pages=3
+            page-input={ for: "website-section", id }
+            attrs={ "aria-label": "load-more", "role": "main" }
+          />
+        </marko-web-resolve-page>
+      </@below-page>
+
+    </marko-web-website-section-page-layout>
+  </marko-web-resolve>
+</marko-web-resolve>

--- a/sites/auadailynews.org/server/routes/home.js
+++ b/sites/auadailynews.org/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/website-section-page');
-const home = require('@ascend-media/package-global/templates/website-section/home');
+const home = require('../templates/website-section/home');
 
 module.exports = (app) => {
   app.get('/', withWebsiteSection({

--- a/sites/auadailynews.org/server/templates/website-section/home.marko
+++ b/sites/auadailynews.org/server/templates/website-section/home.marko
@@ -1,0 +1,126 @@
+import { get, getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { isFunction } from "@parameter1/base-cms-utils";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import websiteSectionContentLoader from "@ascend-media/package-global/loaders/website-section-content";
+import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
+
+$ const { GAM, apollo, site } = out.global;
+$ const nativeXBlock = site.get('nativeXBlock');
+
+$ const {
+  id,
+  alias,
+  name,
+  pageNode,
+} = input;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
+  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail3", size:[300, 600],  aliases }),
+});
+
+$ const promise = websiteSectionContentLoader(apollo, {
+  sectionId: id,
+  featuredParams: {
+    optionName: ["Pinned"],
+    limit: 5,
+    requiresImage: true,
+    queryFragment
+  },
+  standardParams: {
+    optionName: ["Standard"],
+    limit: 10,
+    requiresImage: true,
+    queryFragment
+  },
+  withStandardQuery: true,
+});
+
+<marko-web-resolve|{ resolved: sectionContent }| promise=promise>
+  $ const { featured, standard } = sectionContent;
+  <marko-web-resolve|{ resolved: { data: section } }| promise=pageNode.load()>
+    $ const aliases = hierarchyAliases(section);
+    $ const slots = adSlots({ aliases });
+    <marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+      <@head>
+        <marko-web-gtm-website-section-context|{ context }| alias=alias>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-website-section-context>
+        <marko-web-gam-slots slots=slots />
+      </@head>
+
+      <@above-page>
+        <marko-web-gam-display-ad
+          id="gpt-ad-lb1"
+          slots=slots
+          class="mt-block"
+          modifiers=["max-width-970", "margin-auto-x", "center", "paid"]
+        />
+      </@above-page>
+      <@page>
+        <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
+        <div class="row">
+          <div class="col-lg-8">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+              <@native-x index=0 name="default" />
+            </global-content-card-deck-flow>
+          </div>
+          <div class="col-lg-4">
+            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
+            $ const showSectionTitle = site.get('nativeXBlockSlugs');
+            <global-native-x-list-block
+              placement-name="default"
+              aliases=aliases
+              limit=6
+              collapsible=true
+              title=nativeXBlockTitle
+              with-section=showSectionTitle
+            />
+          </div>
+        </div>
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+
+        <div class="row">
+          <div class="col-lg-4 mb-block">
+            <marko-web-gam-display-ad id="gpt-ad-rail3" />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-twitter-widget-block />
+          </div>
+        </div>
+
+        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center", "paid"] />
+
+      </@page>
+
+      <@below-page>
+        <marko-web-resolve-page|{ data: section }| node=pageNode>
+          $ const aliases = hierarchyAliases(section);
+          $ const loadMoreParams = {
+            sectionId: id,
+            optionName: ["Standard"],
+            excludeContentIds: sectionContent.ids,
+            limit: 12,
+          };
+          <marko-web-load-more
+            component-name="global-content-card-deck-flow"
+            component-input={ aliases, cols: 3, withTeaser: false }
+            fragment-name="global-content-list"
+            query-name="website-scheduled-content"
+            query-params=loadMoreParams
+            max-pages=3
+            page-input={ for: "website-section", id }
+            attrs={ "aria-label": "load-more", "role": "main" }
+          />
+        </marko-web-resolve-page>
+      </@below-page>
+
+    </marko-web-website-section-page-layout>
+  </marko-web-resolve>
+</marko-web-resolve>

--- a/sites/isc.hub.heart.org/server/routes/home.js
+++ b/sites/isc.hub.heart.org/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/website-section-page');
-const home = require('@ascend-media/package-global/templates/website-section/home');
+const home = require('../templates/website-section/home');
 
 module.exports = (app) => {
   app.get('/', withWebsiteSection({

--- a/sites/isc.hub.heart.org/server/templates/website-section/home.marko
+++ b/sites/isc.hub.heart.org/server/templates/website-section/home.marko
@@ -1,0 +1,126 @@
+import { get, getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { isFunction } from "@parameter1/base-cms-utils";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import websiteSectionContentLoader from "@ascend-media/package-global/loaders/website-section-content";
+import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
+
+$ const { GAM, apollo, site } = out.global;
+$ const nativeXBlock = site.get('nativeXBlock');
+
+$ const {
+  id,
+  alias,
+  name,
+  pageNode,
+} = input;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
+  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail3", size:[300, 600],  aliases }),
+});
+
+$ const promise = websiteSectionContentLoader(apollo, {
+  sectionId: id,
+  featuredParams: {
+    optionName: ["Pinned"],
+    limit: 5,
+    requiresImage: true,
+    queryFragment
+  },
+  standardParams: {
+    optionName: ["Standard"],
+    limit: 10,
+    requiresImage: true,
+    queryFragment
+  },
+  withStandardQuery: true,
+});
+
+<marko-web-resolve|{ resolved: sectionContent }| promise=promise>
+  $ const { featured, standard } = sectionContent;
+  <marko-web-resolve|{ resolved: { data: section } }| promise=pageNode.load()>
+    $ const aliases = hierarchyAliases(section);
+    $ const slots = adSlots({ aliases });
+    <marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+      <@head>
+        <marko-web-gtm-website-section-context|{ context }| alias=alias>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-website-section-context>
+        <marko-web-gam-slots slots=slots />
+      </@head>
+
+      <@above-page>
+        <marko-web-gam-display-ad
+          id="gpt-ad-lb1"
+          slots=slots
+          class="mt-block"
+          modifiers=["max-width-970", "margin-auto-x", "center", "paid"]
+        />
+      </@above-page>
+      <@page>
+        <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
+        <div class="row">
+          <div class="col-lg-8">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+              <@native-x index=0 name="default" />
+            </global-content-card-deck-flow>
+          </div>
+          <div class="col-lg-4">
+            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
+            $ const showSectionTitle = site.get('nativeXBlockSlugs');
+            <global-native-x-list-block
+              placement-name="default"
+              aliases=aliases
+              limit=6
+              collapsible=true
+              title=nativeXBlockTitle
+              with-section=showSectionTitle
+            />
+          </div>
+        </div>
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+
+        <div class="row">
+          <div class="col-lg-4 mb-block">
+            <marko-web-gam-display-ad id="gpt-ad-rail3" />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-twitter-widget-block />
+          </div>
+        </div>
+
+        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center", "paid"] />
+
+      </@page>
+
+      <@below-page>
+        <marko-web-resolve-page|{ data: section }| node=pageNode>
+          $ const aliases = hierarchyAliases(section);
+          $ const loadMoreParams = {
+            sectionId: id,
+            optionName: ["Standard"],
+            excludeContentIds: sectionContent.ids,
+            limit: 12,
+          };
+          <marko-web-load-more
+            component-name="global-content-card-deck-flow"
+            component-input={ aliases, cols: 3, withTeaser: false }
+            fragment-name="global-content-list"
+            query-name="website-scheduled-content"
+            query-params=loadMoreParams
+            max-pages=3
+            page-input={ for: "website-section", id }
+            attrs={ "aria-label": "load-more", "role": "main" }
+          />
+        </marko-web-resolve-page>
+      </@below-page>
+
+    </marko-web-website-section-page-layout>
+  </marko-web-resolve>
+</marko-web-resolve>

--- a/sites/sessions.hub.heart.org/server/routes/home.js
+++ b/sites/sessions.hub.heart.org/server/routes/home.js
@@ -1,6 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/website-section-page');
-const home = require('@ascend-media/package-global/templates/website-section/home');
+const home = require('../templates/website-section/home');
 
 module.exports = (app) => {
   app.get('/', withWebsiteSection({

--- a/sites/sessions.hub.heart.org/server/templates/website-section/home.marko
+++ b/sites/sessions.hub.heart.org/server/templates/website-section/home.marko
@@ -1,0 +1,126 @@
+import { get, getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { isFunction } from "@parameter1/base-cms-utils";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import websiteSectionContentLoader from "@ascend-media/package-global/loaders/website-section-content";
+import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
+
+$ const { GAM, apollo, site } = out.global;
+$ const nativeXBlock = site.get('nativeXBlock');
+
+$ const {
+  id,
+  alias,
+  name,
+  pageNode,
+} = input;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
+  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail3", size:[300, 600],  aliases }),
+});
+
+$ const promise = websiteSectionContentLoader(apollo, {
+  sectionId: id,
+  featuredParams: {
+    optionName: ["Pinned"],
+    limit: 5,
+    requiresImage: true,
+    queryFragment
+  },
+  standardParams: {
+    optionName: ["Standard"],
+    limit: 10,
+    requiresImage: true,
+    queryFragment
+  },
+  withStandardQuery: true,
+});
+
+<marko-web-resolve|{ resolved: sectionContent }| promise=promise>
+  $ const { featured, standard } = sectionContent;
+  <marko-web-resolve|{ resolved: { data: section } }| promise=pageNode.load()>
+    $ const aliases = hierarchyAliases(section);
+    $ const slots = adSlots({ aliases });
+    <marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+      <@head>
+        <marko-web-gtm-website-section-context|{ context }| alias=alias>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-website-section-context>
+        <marko-web-gam-slots slots=slots />
+      </@head>
+
+      <@above-page>
+        <marko-web-gam-display-ad
+          id="gpt-ad-lb1"
+          slots=slots
+          class="mt-block"
+          modifiers=["max-width-970", "margin-auto-x", "center", "paid"]
+        />
+      </@above-page>
+      <@page>
+        <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
+        <div class="row">
+          <div class="col-lg-8">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+              <@native-x index=0 name="default" />
+            </global-content-card-deck-flow>
+          </div>
+          <div class="col-lg-4">
+            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
+            $ const showSectionTitle = site.get('nativeXBlockSlugs');
+            <global-native-x-list-block
+              placement-name="default"
+              aliases=aliases
+              limit=6
+              collapsible=true
+              title=nativeXBlockTitle
+              with-section=showSectionTitle
+            />
+          </div>
+        </div>
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+
+        <div class="row">
+          <div class="col-lg-4 mb-block">
+            <marko-web-gam-display-ad id="gpt-ad-rail3" />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+          </div>
+          <div class="col-lg-4 mb-block">
+            <global-twitter-widget-block />
+          </div>
+        </div>
+
+        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center", "paid"] />
+
+      </@page>
+
+      <@below-page>
+        <marko-web-resolve-page|{ data: section }| node=pageNode>
+          $ const aliases = hierarchyAliases(section);
+          $ const loadMoreParams = {
+            sectionId: id,
+            optionName: ["Standard"],
+            excludeContentIds: sectionContent.ids,
+            limit: 12,
+          };
+          <marko-web-load-more
+            component-name="global-content-card-deck-flow"
+            component-input={ aliases, cols: 3, withTeaser: false }
+            fragment-name="global-content-list"
+            query-name="website-scheduled-content"
+            query-params=loadMoreParams
+            max-pages=3
+            page-input={ for: "website-section", id }
+            attrs={ "aria-label": "load-more", "role": "main" }
+          />
+        </marko-web-resolve-page>
+      </@below-page>
+
+    </marko-web-website-section-page-layout>
+  </marko-web-resolve>
+</marko-web-resolve>


### PR DESCRIPTION
![ASA](https://user-images.githubusercontent.com/46794001/195893821-2190f02d-233f-4e20-bd3b-099c6bfe70cf.png)


Essentially pulls 2 stories up to fill in the potential gap of having 6 "Interesting Stories" populated here, otherwise unchanged.

Updated for: AAD, AUA, ISC (Stroke), Sessions and ASA.