### PR TITLE
Remove breaking above-container call on Native-X section page template

### DIFF
--- a/packages/global/templates/website-section/native-x.marko
+++ b/packages/global/templates/website-section/native-x.marko
@@ -40,16 +40,6 @@ $ const promise = websiteSectionContentLoader(apollo, {
         </marko-web-gtm-website-section-context>
         <marko-web-gam-slots slots=slots />
       </@head>
-
-      <@above-container>
-        <@section
-          id=section.id
-          name=section.name
-          alias=section.alias
-          logo=section.logo
-          hierarchy=section.hierarchy
-        />
-      </@above-container>
       <@above-page>
         <marko-web-gam-display-ad
           id="gpt-ad-lb1"


### PR DESCRIPTION
![Screenshot from 2022-10-18 15-15-38](https://user-images.githubusercontent.com/46794001/196534995-22831499-6aaf-49c5-817b-cc7bd2b3a66a.png)
