### PR TITLE
Cleanup Native-X Block configuration options, allow for 9 Interesting Stories AAD

### DIFF
--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -59,7 +59,7 @@
   "<global-standard-hero-block>": {
     "template": "./standard-hero.marko"
   },
-  "<global-global-right-rail-block>": {
+  "<global-right-rail-block>": {
     "template": "./right-rail.marko"
   },
   "<global-notice-pushdown-block>": {

--- a/packages/global/components/blocks/native-x-list.marko
+++ b/packages/global/components/blocks/native-x-list.marko
@@ -3,7 +3,7 @@ import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
 import convertAdToContent from "@parameter1/base-cms-marko-web-native-x/utils/convert-ad-to-content";
 
 $ const { nativeX: nxConfig } = out.global;
-$ const limit = defaultValue(input.limit, 3);
+$ const limit = defaultValue(input.limit, 6);
 $ const placementName = defaultValue(input.placementName, "default");
 $ const aliases = defaultValue(input.aliases, []);
 

--- a/packages/global/components/blocks/right-rail.marko
+++ b/packages/global/components/blocks/right-rail.marko
@@ -2,22 +2,21 @@ $ const { GAM, site } = out.global;
 
 $ const { aliases } = input;
 
-$ const nativeXBlock = site.get('nativeXBlock');
-$ const nativeXBlockTitle = site.get('nativeXBlockTitle');
-$ const withSection = site.get('nativeXBlockSlugs');
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
 
 <marko-web-gam-define-display-ad
-  ...GAM.getAdUnit({ name: 'rail1', aliases })
+  ...GAM.getAdUnit({ name: "rail1", aliases })
   class="mb-block"
 />
 
-<if(nativeXBlock === true)>
+<if(nativeXBlock && nativeXBlock.enabled)>
+  $ const { limit, title, withSection } = nativeXBlock;
   <global-native-x-list-block
     placement-name="default"
     aliases=aliases
-    limit=6
+    limit=limit
     collapsible=true
-    title=nativeXBlockTitle
+    title=title
     with-section=withSection
   />
 </if>
@@ -27,6 +26,6 @@ $ const withSection = site.get('nativeXBlockSlugs');
 </else>
 
 <marko-web-gam-define-display-ad
-...GAM.getAdUnit({ name: 'rail2', aliases })
+...GAM.getAdUnit({ name: "rail2", aliases })
   class="mb-block"
 />

--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -218,7 +218,7 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && restrictedRight
                 />
               </if>
               <else-if(showRightRail)>
-                <global-global-right-rail-block aliases=aliases no-shadow=true />
+                <global-right-rail-block aliases=aliases no-shadow=true />
               </else-if>
             </aside>
 

--- a/packages/global/templates/website-section/home.marko
+++ b/packages/global/templates/website-section/home.marko
@@ -6,7 +6,7 @@ import websiteSectionContentLoader from "@ascend-media/package-global/loaders/we
 import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
 
 $ const { GAM, apollo, site } = out.global;
-$ const nativeXBlock = site.get('nativeXBlock');
+$ const nativeXBlock = site.getAsObject('nativeXBlock');
 
 $ const {
   id,
@@ -70,12 +70,11 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </div>
           <div class="col-lg-4">
             $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
-            <if(nativeXBlock === true)>
+            <if(nativeXBlock && nativeXBlock.enabled)>
             $ const showSectionTitle = site.get('nativeXBlockSlugs');
               <global-native-x-list-block
                 placement-name="default"
                 aliases=aliases
-                limit=6
                 collapsible=true
                 title=nativeXBlockTitle
                 with-section=showSectionTitle

--- a/packages/global/templates/website-section/home.marko
+++ b/packages/global/templates/website-section/home.marko
@@ -70,12 +70,12 @@ $ const promise = websiteSectionContentLoader(apollo, {
           </div>
           <div class="col-lg-4">
             <if(nativeXBlock && nativeXBlock.enabled)>
-            $ const { withSection } = nativeXBlock;
+            $ const { title, withSection } = nativeXBlock;
               <global-native-x-list-block
                 placement-name="default"
                 aliases=aliases
                 collapsible=true
-                title=nativeXBlockTitle
+                title=title
                 with-section=withSection
               />
             </if>

--- a/packages/global/templates/website-section/home.marko
+++ b/packages/global/templates/website-section/home.marko
@@ -6,7 +6,7 @@ import websiteSectionContentLoader from "@ascend-media/package-global/loaders/we
 import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
 
 $ const { GAM, apollo, site } = out.global;
-$ const nativeXBlock = site.getAsObject('nativeXBlock');
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
 
 $ const {
   id,
@@ -69,15 +69,14 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </global-content-card-deck-flow>
           </div>
           <div class="col-lg-4">
-            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
             <if(nativeXBlock && nativeXBlock.enabled)>
-            $ const showSectionTitle = site.get('nativeXBlockSlugs');
+            $ const { withSection } = nativeXBlock;
               <global-native-x-list-block
                 placement-name="default"
                 aliases=aliases
                 collapsible=true
                 title=nativeXBlockTitle
-                with-section=showSectionTitle
+                with-section=withSection
               />
             </if>
             <else>

--- a/sites/aadmeetingnews.org/config/site.js
+++ b/sites/aadmeetingnews.org/config/site.js
@@ -4,7 +4,10 @@ const logos = require('./logos');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+    limit: 9,
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   contentPageLoadMoreSettings: {

--- a/sites/aadmeetingnews.org/server/templates/website-section/home.marko
+++ b/sites/aadmeetingnews.org/server/templates/website-section/home.marko
@@ -31,7 +31,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 10,
+    limit: 12,
     requiresImage: true,
     queryFragment
   },
@@ -64,31 +64,31 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 7) ad-index=4 ad-name="rail2">
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
-          <div class="col-lg-4">
+          <div class="col-lg-4 mb-block">
             $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
             $ const showSectionTitle = site.get('nativeXBlockSlugs');
             <global-native-x-list-block
               placement-name="default"
               aliases=aliases
-              limit=6
+              limit=9
               collapsible=true
               title=nativeXBlockTitle
               with-section=showSectionTitle
             />
           </div>
         </div>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 10) cols=3 />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-4 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(10, 12) cols=1 />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />

--- a/sites/aadmeetingnews.org/server/templates/website-section/home.marko
+++ b/sites/aadmeetingnews.org/server/templates/website-section/home.marko
@@ -6,7 +6,7 @@ import websiteSectionContentLoader from "@ascend-media/package-global/loaders/we
 import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
 
 $ const { GAM, apollo, site } = out.global;
-$ const nativeXBlock = site.get('nativeXBlock');
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
 
 $ const {
   id,
@@ -63,22 +63,23 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
-          <div class="col-lg-8">
+          <div class="col-lg-8 mb-block">
             <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 7) ad-index=4 ad-name="rail2">
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
           <div class="col-lg-4 mb-block">
-            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
-            $ const showSectionTitle = site.get('nativeXBlockSlugs');
-            <global-native-x-list-block
-              placement-name="default"
-              aliases=aliases
-              limit=9
-              collapsible=true
-              title=nativeXBlockTitle
-              with-section=showSectionTitle
-            />
+            <if(nativeXBlock && nativeXBlock.enabled)>
+              $ const { limit, title, withSection } = nativeXBlock;
+              <global-native-x-list-block
+                placement-name="default"
+                aliases=aliases
+                limit=limit
+                collapsible=true
+                title=title
+                with-section=withSection
+              />
+            </if>
           </div>
         </div>
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 10) cols=3 />

--- a/sites/aao.hns.org/config/site.js
+++ b/sites/aao.hns.org/config/site.js
@@ -4,7 +4,9 @@ const logos = require('./logos');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,

--- a/sites/acep.org/config/site.js
+++ b/sites/acep.org/config/site.js
@@ -4,10 +4,12 @@ const logos = require('./logos');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+    title: 'ACEP22 Newsroom',
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
-  nativeXBlockTitle: 'ACEP22 Newsroom',
   logos,
   navigation,
   gam,

--- a/sites/asa.org/config/site.js
+++ b/sites/asa.org/config/site.js
@@ -4,12 +4,14 @@ const logos = require('./logos');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+    title: 'From The ASA Monitor',
+    withSection: false,
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   searchTitle: 'Search Annual Meeting Daily News',
-  nativeXBlockTitle: 'From The ASA Monitor',
-  nativeXBlockSlugs: false,
   logos,
   navigation,
   gam,

--- a/sites/asa.org/server/templates/website-section/home.marko
+++ b/sites/asa.org/server/templates/website-section/home.marko
@@ -6,7 +6,7 @@ import websiteSectionContentLoader from "@ascend-media/package-global/loaders/we
 import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
 
 $ const { GAM, apollo, site } = out.global;
-$ const nativeXBlock = site.get('nativeXBlock');
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
 
 $ const {
   id,
@@ -63,22 +63,23 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
-          <div class="col-lg-8">
+          <div class="col-lg-8 mb-block">
             <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
-          <div class="col-lg-4">
-            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
-            $ const showSectionTitle = site.get('nativeXBlockSlugs');
-            <global-native-x-list-block
-              placement-name="default"
-              aliases=aliases
-              limit=6
-              collapsible=true
-              title=nativeXBlockTitle
-              with-section=showSectionTitle
-            />
+          <div class="col-lg-4 mb-block">
+            <if(nativeXBlock && nativeXBlock.enabled)>
+            $ const { limit, title, withSection } = nativeXBlock;
+              <global-native-x-list-block
+                placement-name="default"
+                aliases=aliases
+                collapsible=true
+                limit=limit
+                title=title
+                with-section=withSection
+              />
+            </if>
           </div>
         </div>
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />

--- a/sites/ashp.org/config/site.js
+++ b/sites/ashp.org/config/site.js
@@ -4,10 +4,12 @@ const logos = require('./logos');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+    title: 'Featured Stories',
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
-  nativeXBlockTitle: 'Featured Stories',
   logos,
   navigation,
   gam,

--- a/sites/ashp.org/server/templates/index.marko
+++ b/sites/ashp.org/server/templates/index.marko
@@ -6,7 +6,7 @@ import websiteSectionContentLoader from "@ascend-media/package-global/loaders/we
 import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
 
 $ const { GAM, apollo, site } = out.global;
-$ const nativeXBlock = site.get('nativeXBlock');
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
 
 $ const {
   id,
@@ -63,20 +63,21 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
-          <div class="col-lg-8">
+          <div class="col-lg-8 mb-block">
             <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 4)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
-          <div class="col-lg-4">
-            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
-            <if(nativeXBlock === true)>
+          <div class="col-lg-4 mb-block">
+            <if(nativeXBlock && nativeXBlock.enabled)>
+              $ const { limit, title, withSection } = nativeXBlock
               <global-native-x-list-block
                 placement-name="default"
                 aliases=aliases
-                limit=6
+                limit=limit
                 collapsible=true
-                title=nativeXBlockTitle
+                title=title
+                with-section=withSection
               />
             </if>
             <else>

--- a/sites/auadailynews.org/config/site.js
+++ b/sites/auadailynews.org/config/site.js
@@ -4,7 +4,9 @@ const logos = require('./logos');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,

--- a/sites/auadailynews.org/server/templates/website-section/home.marko
+++ b/sites/auadailynews.org/server/templates/website-section/home.marko
@@ -6,7 +6,7 @@ import websiteSectionContentLoader from "@ascend-media/package-global/loaders/we
 import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
 
 $ const { GAM, apollo, site } = out.global;
-$ const nativeXBlock = site.get('nativeXBlock');
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
 
 $ const {
   id,
@@ -63,22 +63,23 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
-          <div class="col-lg-8">
+          <div class="col-lg-8 mb-block">
             <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
-          <div class="col-lg-4">
-            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
-            $ const showSectionTitle = site.get('nativeXBlockSlugs');
-            <global-native-x-list-block
-              placement-name="default"
-              aliases=aliases
-              limit=6
-              collapsible=true
-              title=nativeXBlockTitle
-              with-section=showSectionTitle
-            />
+          <div class="col-lg-4 mb-block">
+            <if(nativeXBlock && nativeXBlock.enabled)>
+              $ const { limit, title, withSection } = nativeXBlock;
+              <global-native-x-list-block
+                placement-name="default"
+                aliases=aliases
+                limit=limit
+                collapsible=true
+                title=title
+                with-section=withSection
+              />
+            </if>
           </div>
         </div>
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />

--- a/sites/isc.hub.heart.org/config/site.js
+++ b/sites/isc.hub.heart.org/config/site.js
@@ -4,7 +4,9 @@ const logos = require('./logos');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,

--- a/sites/isc.hub.heart.org/server/templates/website-section/home.marko
+++ b/sites/isc.hub.heart.org/server/templates/website-section/home.marko
@@ -6,7 +6,7 @@ import websiteSectionContentLoader from "@ascend-media/package-global/loaders/we
 import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
 
 $ const { GAM, apollo, site } = out.global;
-$ const nativeXBlock = site.get('nativeXBlock');
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
 
 $ const {
   id,
@@ -63,22 +63,23 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
-          <div class="col-lg-8">
+          <div class="col-lg-8 mb-block">
             <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
-          <div class="col-lg-4">
-            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
-            $ const showSectionTitle = site.get('nativeXBlockSlugs');
-            <global-native-x-list-block
-              placement-name="default"
-              aliases=aliases
-              limit=6
-              collapsible=true
-              title=nativeXBlockTitle
-              with-section=showSectionTitle
-            />
+          <div class="col-lg-4 mb-block">
+            <if(nativeXBlock && nativeXBlock.enabled)>
+              $ const { limit, title, withSection } = nativeXBlock;
+              <global-native-x-list-block
+                placement-name="default"
+                aliases=aliases
+                limit=limit
+                collapsible=true
+                title=title
+                with-section=withSection
+              />
+            </if>
           </div>
         </div>
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />

--- a/sites/sessions.hub.heart.org/config/site.js
+++ b/sites/sessions.hub.heart.org/config/site.js
@@ -5,7 +5,9 @@ const blocks = require('./blocks');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   blocks,

--- a/sites/sessions.hub.heart.org/server/templates/website-section/home.marko
+++ b/sites/sessions.hub.heart.org/server/templates/website-section/home.marko
@@ -6,7 +6,7 @@ import websiteSectionContentLoader from "@ascend-media/package-global/loaders/we
 import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
 
 $ const { GAM, apollo, site } = out.global;
-$ const nativeXBlock = site.get('nativeXBlock');
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
 
 $ const {
   id,
@@ -63,22 +63,23 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
-          <div class="col-lg-8">
+          <div class="col-lg-8 mb-block">
             <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
-          <div class="col-lg-4">
-            $ const nativeXBlockTitle = site.get('nativeXBlockTitle');
-            $ const showSectionTitle = site.get('nativeXBlockSlugs');
-            <global-native-x-list-block
-              placement-name="default"
-              aliases=aliases
-              limit=6
-              collapsible=true
-              title=nativeXBlockTitle
-              with-section=showSectionTitle
-            />
+          <div class="col-lg-4 mb-block">
+            <if(nativeXBlock && nativeXBlock.enabled)>
+              $ const { limit, title, withSection } = nativeXBlock;
+              <global-native-x-list-block
+                placement-name="default"
+                aliases=aliases
+                limit=limit
+                collapsible=true
+                title=title
+                with-section=withSection
+              />
+            </if>
           </div>
         </div>
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />

--- a/sites/shm.org/config/site.js
+++ b/sites/shm.org/config/site.js
@@ -4,7 +4,9 @@ const logos = require('./logos');
 const nativeX = require('./native-x');
 
 module.exports = {
-  nativeXBlock: Boolean(process.env.NATIVE_X_BLOCK),
+  nativeXBlock: {
+    enabled: Boolean(process.env.NATIVE_X_BLOCK),
+  },
   restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,


### PR DESCRIPTION
![9-Interesting-Stories-Proper](https://user-images.githubusercontent.com/46794001/196747600-fbe7b5fd-c1cf-4457-ba48-9640e47e08d2.png)


In this PR:

- Support 9 Interesting Stories AAD homepage. https://github.com/parameter1/ascend-media-websites/commit/5e1f23b239292e2eef63d2fa16b780cfcc7ed06b
- Correct naming of global-right-rail-block. https://github.com/parameter1/ascend-media-websites/commit/1c6d2da516ce3ce44412b46784a578a6f7336ce8
- Up default limit of native-x-list-block to 6. https://github.com/parameter1/ascend-media-websites/commit/01f5e12aa6ba96c5e632ff2ba93b994dafa87b44
- Setup right rail via site config object over fields. https://github.com/parameter1/ascend-media-websites/commit/6d3c6ebd5a7bde39a033777820f300a9043d9ca9
- Rename global-right-rail in content template. https://github.com/parameter1/ascend-media-websites/commit/26987d7f4569a6a28d4a9b219354b7db18fd55da
- Use site config object and default limit on home. https://github.com/parameter1/ascend-media-websites/commit/86607dc43cd86334b899e85bfe5318f10cad7643
- Additional configuration correction on homepage(s). https://github.com/parameter1/ascend-media-websites/commit/06f87d65d755efcb614bf9a7dcffc96373e80349
- Update site configuratiosn to use new format. https://github.com/parameter1/ascend-media-websites/commit/da8dc11425bf678e9dbe5dfac7d3b40488623fb1
- Use applicable variables on shared home template. https://github.com/parameter1/ascend-media-websites/commit/01959dc54c6bdd0aa633b44ba68762666ff5b61f
- Unify logic on individual site homepage templates. https://github.com/parameter1/ascend-media-websites/commit/5390d15cc780a27917c80c5e47247c38ce29a476
