### PR TITLE
Display teaser and allow for static setting of titles for Native-X hero blocks

### DIFF
--- a/packages/daily/components/blocks/native-x-hero-card.marko
+++ b/packages/daily/components/blocks/native-x-hero-card.marko
@@ -6,8 +6,6 @@ $ const { nativeX: nxConfig } = out.global;
 $ const placementName = defaultValue(input.placementName, "default");
 $ const aliases = defaultValue(input.aliases, []);
 
-$ const modifiers = input.modifiers || [];
-$ modifiers.push("native-x-list");
 $ const uri = nxConfig.getUri();
 $ const placement = nxConfig.getPlacement({ name: placementName, aliases });
 
@@ -19,7 +17,8 @@ $ const placement = nxConfig.getPlacement({ name: placementName, aliases });
       ...convertAdToContent(ad, { sectionName: `Sponsored by ${ad.campaign.advertiserName}` }),
       attributes: {
         ...ad.attributes
-      }
+      },
+      ...(input.header && { shortName: input.header })
     }
     $ const primaryImage = getAsObject(content, "primaryImage");
     <marko-web-node
@@ -49,6 +48,11 @@ $ const placement = nxConfig.getPlacement({ name: placementName, aliases });
           is-logo=primaryImage.isLogo
           link={ href: content.siteContext.path, attrs: getAsObject(content, "attributes.link") }
         >
+          <@body>
+            <@text modifiers=["teaser"] show=Boolean(content.teaser)>
+              <marko-web-content-teaser tag=null obj=content link=true />
+            </@text>
+          </@body>
         </@image>
     </marko-web-node>
   </if>

--- a/sites/bulletin.entnet.org/server/styles/index.scss
+++ b/sites/bulletin.entnet.org/server/styles/index.scss
@@ -189,14 +189,19 @@ $theme-card-header-background-color: #fff;
   }
 }
 
-/* .document-container {
+.document-container {
   &--classifieds {
-    @if $marko-web-document-container-max-width {
-      @media (min-width: $marko-web-document-container-max-width) {
-        max-width: 100%;
-        padding-right: 0;
-        padding-left: 0;
+    .node {
+      &--hero {
+        .node {
+          &__header {
+            a {
+              font-size: 1rem;
+              font-weight: 600;
+            }
+          }
+        }
       }
     }
   }
-} */
+}

--- a/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
+++ b/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
@@ -35,6 +35,7 @@ $ const adSlots = ({ aliases }) => ({
                   <daily-native-x-hero-card-block 
                     placement-name="default"
                     aliases=["employment"]
+                    header="Featured Employment"
                   />
                 </div>
                 <div class="col-lg-12 mb-block-lg">
@@ -55,6 +56,7 @@ $ const adSlots = ({ aliases }) => ({
                   <daily-native-x-hero-card-block 
                     placement-name="default"
                     aliases=["courses-meetings"]
+                    header="Featured Courses & Meetings"
                   />
                 </div>
                 <div class="col-lg-12 mb-block-lg">


### PR DESCRIPTION
Showing this is able to be statically set from the component calling it:
![Showing-It-Is-Statically-Set](https://user-images.githubusercontent.com/46794001/197535652-4f150edf-9b29-4aad-9e7c-9dac3d42f28a.png)

Showing this displaying as PR'd (the ads already had these set as their titles so it doesn't really make a difference currently):
![Showing-It-Correctly](https://user-images.githubusercontent.com/46794001/197535655-553b4372-5155-4fc6-96c5-8c13a1674e30.png)
