### PR TITLE
Remove ‘Presented by {company}’ on story page

### DIFF
--- a/packages/daily/templates/content/native-x-story.marko
+++ b/packages/daily/templates/content/native-x-story.marko
@@ -23,6 +23,7 @@ $ const src = buildImgixUrl(content.primaryImage.src, imageOptions);
         <div class="content-page-header">
           <marko-web-content-name tag="h1" block-name=blockName obj=content />
           <!-- <presented-by advertiser=story.advertiser /> -->
+          <marko-web-content-teaser tag="h3" obj=content />
         </div>
         </div>
       </@section>

--- a/packages/daily/templates/content/native-x-story.marko
+++ b/packages/daily/templates/content/native-x-story.marko
@@ -22,7 +22,7 @@ $ const src = buildImgixUrl(content.primaryImage.src, imageOptions);
         <div class="content-page-primary-image" style=`width: 100%; height: ${imageOptions.h}px; background-image:url(${src})`>
         <div class="content-page-header">
           <marko-web-content-name tag="h1" block-name=blockName obj=content />
-          <presented-by advertiser=story.advertiser />
+          <!-- <presented-by advertiser=story.advertiser /> -->
         </div>
         </div>
       </@section>

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -22,7 +22,7 @@ $ const src = buildImgixUrl(content.primaryImage.src, imageOptions);
         <div class="content-page-primary-image" style=`width: 100%; height: ${imageOptions.h}px; background-image:url(${src})`>
         <div class="content-page-header">
           <marko-web-content-name tag="h1" block-name=blockName obj=content />
-          <presented-by advertiser=story.advertiser />
+          <!-- <presented-by advertiser=story.advertiser /> -->
           <marko-web-content-teaser tag="h3" obj=content />
         </div>
         </div>


### PR DESCRIPTION
Change:
<img width="1320" alt="Screen Shot 2022-10-24 at 11 47 41 AM" src="https://user-images.githubusercontent.com/64623209/197581211-4dcf808f-c94b-491d-8b1f-0b6373ab2234.png">

Current:
<img width="1353" alt="Screen Shot 2022-10-24 at 11 48 02 AM" src="https://user-images.githubusercontent.com/64623209/197581220-1646e368-747f-4ed4-8d52-8ae3768ea8ab.png">
