### PR TITLE
Allow for 8 digits to appear in content slug and still route content to correct page

### DIFF
--- a/sites/aadmeetingnews.org/server/routes/content.js
+++ b/sites/aadmeetingnews.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/aao.hns.org/server/routes/content.js
+++ b/sites/aao.hns.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/acep.org/server/routes/content.js
+++ b/sites/acep.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/asa.org/server/routes/content.js
+++ b/sites/asa.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/ashp.org/server/routes/content.js
+++ b/sites/ashp.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/auadailynews.org/server/routes/content.js
+++ b/sites/auadailynews.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/bcvs.hub.heart.org/server/routes/content.js
+++ b/sites/bcvs.hub.heart.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/bulletin.entnet.org/server/routes/content.js
+++ b/sites/bulletin.entnet.org/server/routes/content.js
@@ -8,7 +8,7 @@ module.exports = (app) => {
     template: contact,
     queryFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/hearthubs.org/server/routes/content.js
+++ b/sites/hearthubs.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/hypertension.hub.heart.org/server/routes/content.js
+++ b/sites/hypertension.hub.heart.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/imex.ascendmedia.com/server/routes/content.js
+++ b/sites/imex.ascendmedia.com/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/imexfrankfurt.ascendmedia.com/server/routes/content.js
+++ b/sites/imexfrankfurt.ascendmedia.com/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/isc.hub.heart.org/server/routes/content.js
+++ b/sites/isc.hub.heart.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/minexpo.com/server/routes/content.js
+++ b/sites/minexpo.com/server/routes/content.js
@@ -14,7 +14,7 @@ module.exports = (app) => {
     template: content,
     queryFragment: contactQueryFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/qcor.hub.heart.org/server/routes/content.js
+++ b/sites/qcor.hub.heart.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/sessions.hub.heart.org/server/routes/content.js
+++ b/sites/sessions.hub.heart.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/shm.org/server/routes/content.js
+++ b/sites/shm.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));

--- a/sites/vasculardiscovery.hub.heart.org/server/routes/content.js
+++ b/sites/vasculardiscovery.hub.heart.org/server/routes/content.js
@@ -9,7 +9,7 @@ module.exports = (app) => {
     template: company,
     queryFragment: companyFragment,
   }));
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
     template: content,
     queryFragment,
   }));


### PR DESCRIPTION
Ref: https://github.com/parameter1/randall-reilly-websites/pull/289

Production:
<img width="1920" alt="Screen Shot 2022-11-02 at 8 20 00 AM" src="https://user-images.githubusercontent.com/46794001/199500265-426bb93b-2664-4789-a204-fd90576a951b.png">

Development:
<img width="1920" alt="Screen Shot 2022-11-02 at 8 20 12 AM" src="https://user-images.githubusercontent.com/46794001/199500269-bddd51a3-c538-4fc0-a655-8b9620e35a11.png">