### PR TITLE
Replace More Articles block on Content pages with 300x250 ad

### DIFF
--- a/packages/bulletin/templates/content/index.marko
+++ b/packages/bulletin/templates/content/index.marko
@@ -12,6 +12,7 @@ $ const adSlots = ({ aliases }) => ({
   "gpt-ad-lb3": GAM.getAdUnit({ name: "lb3", aliases }),
   "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
   "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
+  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail3", aliases })
 });
 
 <marko-web-content-page-layout id=id type=type>
@@ -57,17 +58,7 @@ $ const adSlots = ({ aliases }) => ({
               <marko-web-resolve|{ resolved }| promise=issuePromise>
                 $ const { issue, issueContent } = resolved;
                 <if(issue)>
-                  <daily-content-list-flow
-                    nodes=issueContent.nodes.slice(0,3)
-                    inner-justified=false
-                    flush-x=false
-                    flush-y=false
-                  >
-                    <@header>More Articles</@header>
-                    <@node with-dates=false with-teaser=false display-image=false with-attribution=false with-section=false>
-                      <@title modifiers=["small"] />
-                    </@node>
-                  </daily-content-list-flow>
+                  <marko-web-gam-display-ad id="gpt-ad-rail3" />
                   <bulletin-magazine-latest-issue-node card=true flush=false card=false node=issue />
                 </if>
               </marko-web-resolve>

--- a/sites/bulletin.entnet.org/config/gam.js
+++ b/sites/bulletin.entnet.org/config/gam.js
@@ -26,6 +26,7 @@ config
     { name: 'lb3', templateName: 'leaderboard600x100', path: 'lb3' },
     { name: 'rail1', options: { size: [300, 250] }, path: 'rail1' },
     { name: 'rail2', options: { size: [300, 250] }, path: 'rail2' },
+    { name: 'rail3', options: { size: [300, 250] }, path: 'rail3' },
   ]);
 
 module.exports = config;


### PR DESCRIPTION
What it will look like when populated:
<img width="1792" alt="Screen Shot 2022-11-09 at 10 01 52 AM" src="https://user-images.githubusercontent.com/46794001/200880763-9cc129be-6c0e-4dda-b4f4-8f3245ed865e.png">

Verification that ad unit is "loaded":
<img width="1792" alt="Screen Shot 2022-11-09 at 10 03 54 AM" src="https://user-images.githubusercontent.com/46794001/200880811-681254f0-11db-44f5-a1e2-63a51b6d46a3.png">
