### PR TITLE
Implement 'Featured Exhibitors' Native-X block, alter navigation label for 'Register Now', IMEX Frankfurt

### DIFF
--- a/sites/imexfrankfurt.ascendmedia.com/config/navigation.js
+++ b/sites/imexfrankfurt.ascendmedia.com/config/navigation.js
@@ -13,7 +13,7 @@ const topics = [
   { href: '/accommodations-venues', label: 'Accommodation & Venues' },
   { href: '/happenings', label: 'Happenings' },
   { href: '/featured-exhibitors', label: 'Featured Exhibitors' },
-  { href: 'https://www.imex-frankfurt.com', label: 'IMEX in Frankfurt', target: '_blank' },
+  { href: 'https://www.imex-frankfurt.com', label: 'Register Now', target: '_blank' },
 
 ];
 

--- a/sites/imexfrankfurt.ascendmedia.com/server/components/blocks/global-right-rail.marko
+++ b/sites/imexfrankfurt.ascendmedia.com/server/components/blocks/global-right-rail.marko
@@ -1,15 +1,10 @@
-
 <marko-web-gam-display-ad id="gpt-ad-rail1" />
 
-<a
-  class="twitter-timeline btn btn-primary btn-block"
-  data-height="650"
-  data-theme="light"
-  href="https://twitter.com/IMEX_Group?ref_src=twsrc%5Etfw"
-  target="_blank"
->
-  Tweets by IMEX Group
-</a>
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<daily-native-x-list-block
+  placement-name="default"
+  limit=6
+  collapsible=true
+  title="Featured Exhibitors"
+/>
 
 <marko-web-gam-display-ad id="gpt-ad-rail2" class="mt-block-lg" />

--- a/sites/imexfrankfurt.ascendmedia.com/server/templates/index.marko
+++ b/sites/imexfrankfurt.ascendmedia.com/server/templates/index.marko
@@ -47,6 +47,14 @@ $ const adSlots = ({ aliases }) => ({
         </div>
 
         <div class="col-lg-4 mb-block-lg page-rail">
+          <daily-native-x-list-block
+            placement-name="default"
+            aliases=aliases
+            limit=6
+            collapsible=true
+            title="Featured Exhibitors"
+          />
+          <marko-web-gam-display-ad id="gpt-ad-rail2" class="mt-block-lg" />
           <a
             class="twitter-timeline btn btn-primary btn-block"
             data-height="650"
@@ -57,8 +65,6 @@ $ const adSlots = ({ aliases }) => ({
             Tweets by IMEX Group
           </a>
           <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-          <marko-web-gam-display-ad id="gpt-ad-rail2" class="mt-block-lg" />
         </div>
       </div>
 
@@ -81,8 +87,6 @@ $ const adSlots = ({ aliases }) => ({
           </daily-section-list-block>
         </div>
       </div>
-
-      <daily-featured-exhibitors-block section-alias="featured-exhibitors" />
 
     </marko-web-resolve-page>
   </@page>


### PR DESCRIPTION
<img width="653" alt="Screen Shot 2022-12-12 at 10 58 26 AM" src="https://user-images.githubusercontent.com/64623209/207107556-5028521c-48b9-4fb5-a41b-c14a146088e3.png">

<img width="650" alt="Screen Shot 2022-12-12 at 11 04 36 AM" src="https://user-images.githubusercontent.com/64623209/207107997-d5dcd110-0f1c-4574-bdd3-7738ae57b96d.png">