### PR TITLE
Daily Theme Support for fixed Native-X positions

### DIFF
--- a/packages/daily/components/blocks/content-featured.marko
+++ b/packages/daily/components/blocks/content-featured.marko
@@ -17,6 +17,13 @@ $ const queryParams = {
 };
 
 <marko-web-query|{ nodes }| name="website-optioned-content" params=queryParams>
+  <!-- Native-X here uses base 0 indexing whereas limit is defined using base 1 -->
+  $ const slotInNativeX = (nativeX && nativeX.index && ((nativeX.index + 1) !== nodes.length));
+  $ const finalizedNodes =  slotInNativeX ? [
+    ...nodes.slice(0, nativeX.index),
+    {},
+    ...nodes.slice(nativeX.index, nodes.length - 1)
+  ] : nodes;
   <marko-web-node-list
     inner-justified=false
     flush-x=false
@@ -26,44 +33,46 @@ $ const queryParams = {
     <@header>
       Daily News
     </@header>
-    <@nodes nodes=nodes>
+    <@nodes nodes=finalizedNodes>
       <@slot|{ node, index }|>
-          <marko-web-native-x-render|{ node: nxNode, linkAttrs, containerAttrs }|
-            ...nativeX
-            when=(index === nativeX.index)
-            node=node
-            config=nxConfig
-          >
+        <marko-web-native-x-render|{ node: nxNode, linkAttrs, containerAttrs }|
+          ...nativeX
+          when=(index === nativeX.index)
+          node=node
+          config=nxConfig
+        >
             $ const primaryImage = getAsObject(nxNode, "primaryImage");
             $ const primarySection = getAsObject(nxNode, "primarySection");
-            <marko-web-node
-              type=`${nxNode.type}-content`
-              image-position="left"
-              flush=true
-              full-height=false
-              attrs=containerAttrs
-            >
-              <@image
-                ar="1:1"
-                width="125"
-                use-placeholder=false
-                src=primaryImage.src
-                link={ href: get(nxNode, "siteContext.path"), attrs: linkAttrs }
-              />
-              <@body>
-                <@header>
-                  <@left>
-                    <marko-web-website-section-name obj=primarySection link=true />
-                  </@left>
-                </@header>
-                <@title tag="h5">
-                  <marko-web-content-short-name tag=null obj=nxNode link={ attrs: linkAttrs }/>
-                </@title>
-                <@text modifiers=["teaser"] show=Boolean(nxNode.teaser)>
-                  <marko-web-content-teaser tag=null obj=nxNode link={ attrs: linkAttrs } />
-                </@text>
-              </@body>
-            </marko-web-node>
+            <if((index === nativeX.index && nodes[nativeX.index].id !== nxNode.id) || index !== nativeX.index)>
+              <marko-web-node
+                type=`${nxNode.type}-content`
+                image-position="left"
+                flush=true
+                full-height=false
+                attrs=containerAttrs
+              >
+                <@image
+                  ar="1:1"
+                  width="125"
+                  use-placeholder=false
+                  src=primaryImage.src
+                  link={ href: get(nxNode, "siteContext.path"), attrs: linkAttrs }
+                />
+                <@body>
+                  <@header>
+                    <@left>
+                      <marko-web-website-section-name obj=primarySection link=true />
+                    </@left>
+                  </@header>
+                  <@title tag="h5">
+                    <marko-web-content-short-name tag=null obj=nxNode link={ attrs: linkAttrs }/>
+                  </@title>
+                  <@text modifiers=["teaser"] show=Boolean(nxNode.teaser)>
+                    <marko-web-content-teaser tag=null obj=nxNode link={ attrs: linkAttrs } />
+                  </@text>
+                </@body>
+              </marko-web-node>
+          </if>
         </marko-web-native-x-render>
       </@slot>
     </@nodes>

--- a/packages/daily/components/blocks/section-list.marko
+++ b/packages/daily/components/blocks/section-list.marko
@@ -25,6 +25,13 @@ $ const queryParams = {
 };
 
 <marko-web-query|{ nodes, section }| name="website-scheduled-content" params=queryParams>
+  <!-- Native-X here uses base 0 indexing whereas limit is defined using base 1 -->
+  $ const slotInNativeX = (nativeX && nativeX.index && ((nativeX.index + 1) !== nodes.length));
+  $ const finalizedNodes =  slotInNativeX ? [
+    ...nodes.slice(0, nativeX.index),
+    {},
+    ...nodes.slice(nativeX.index, nodes.length - 1)
+  ] : nodes;
   <marko-web-node-list
     inner-justified=innerJustified
     flush-x=false
@@ -40,7 +47,7 @@ $ const queryParams = {
         <marko-web-website-section-name obj=section link=linkHeader />
       </else>
     </@header>
-    <@nodes nodes=nodes>
+    <@nodes nodes=finalizedNodes>
       <@slot|{ node, index }|>
         <marko-web-native-x-render|{ node: nxNode, linkAttrs, containerAttrs }|
           ...nativeX
@@ -50,38 +57,40 @@ $ const queryParams = {
         >
           $ const primaryImage = getAsObject(nxNode, "primaryImage");
           $ const primarySection = getAsObject(nxNode, "primarySection");
-          <marko-web-node
-            image-position=imagePosition
-            flush=true
-            full-height=false
-            attrs=containerAttrs
-          >
-            <@image
-              ar="1:1"
-              width=imageWidth
-              use-placeholder=false
-              src=primaryImage.src
-              alt=primaryImage.alt
-              is-logo=primaryImage.isLogo
-              link={ href: get(nxNode, "siteContext.path"), attrs: linkAttrs }
-              ...input.image
-            />
-            <@body>
-              <if(withSection)>
-                <@header>
-                  <@left>
-                    <marko-web-website-section-name obj=primarySection link=true />
-                  </@left>
-                </@header>
-                </if>
-              <@title tag="h5">
-                <marko-web-content-short-name tag=null obj=nxNode link={ attrs: linkAttrs } />
-              </@title>
-              <@text modifiers=["teaser"] show=withTeaser>
-                <marko-web-content-teaser tag=null obj=nxNode link={ attrs: linkAttrs } />
-              </@text>
-            </@body>
-          </marko-web-node>
+          <if((index === nativeX.index && nodes[nativeX.index].id !== nxNode.id) || index !== nativeX.index)>
+            <marko-web-node
+              image-position=imagePosition
+              flush=true
+              full-height=false
+              attrs=containerAttrs
+            >
+              <@image
+                ar="1:1"
+                width=imageWidth
+                use-placeholder=false
+                src=primaryImage.src
+                alt=primaryImage.alt
+                is-logo=primaryImage.isLogo
+                link={ href: get(nxNode, "siteContext.path"), attrs: linkAttrs }
+                ...input.image
+              />
+              <@body>
+                <if(withSection)>
+                  <@header>
+                    <@left>
+                      <marko-web-website-section-name obj=primarySection link=true />
+                    </@left>
+                  </@header>
+                  </if>
+                <@title tag="h5">
+                  <marko-web-content-short-name tag=null obj=nxNode link={ attrs: linkAttrs } />
+                </@title>
+                <@text modifiers=["teaser"] show=withTeaser>
+                  <marko-web-content-teaser tag=null obj=nxNode link={ attrs: linkAttrs } />
+                </@text>
+              </@body>
+            </marko-web-node>
+          </if>
         </marko-web-native-x-render>
       </@slot>
     </@nodes>

--- a/packages/daily/components/flows/content/card-deck.marko
+++ b/packages/daily/components/flows/content/card-deck.marko
@@ -3,10 +3,18 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { GAM, nativeX: nxConfig } = out.global;
 
-$ const { aliases, adIndex, adName } = input;
+$ const { aliases, adIndex, adName, nodes } = input;
 $ const adPosition = input.adPosition || "after";
 $ const image = getAsObject(input, "node.image");
 $ const nativeX = getAsObject(input, "nativeX");
+
+<!-- Native-X here uses base 0 indexing whereas Array.length uses base 1 -->
+$ const slotInNativeX = (nativeX && nativeX.index && ((nativeX.index + 1) !== nodes.length));
+$ const finalizedNodes = slotInNativeX ? [
+  ...nodes.slice(0, nativeX.index),
+  {},
+  ...nodes.slice(nativeX.index, nodes.length - 1)
+] : nodes;
 
 <default-theme-card-deck-flow
   tag=input.tag
@@ -14,7 +22,7 @@ $ const nativeX = getAsObject(input, "nativeX");
   modifiers=input.modifiers
   attrs=input.attrs
   cols=defaultValue(input.cols, 3)
-  nodes=input.nodes
+  nodes=finalizedNodes
 >
   <@slot|{ node, index }|>
     <marko-web-native-x-render|{ node: nxNode, linkAttrs, containerAttrs }|
@@ -23,7 +31,9 @@ $ const nativeX = getAsObject(input, "nativeX");
       node=node
       config=nxConfig
     >
-      <daily-content-card-node ...input.node node=nxNode attrs=containerAttrs link-attrs=linkAttrs/>
+      <if((index === nativeX.index && nodes[nativeX.index].id !== nxNode.id) || index !== nativeX.index)>
+        <daily-content-card-node ...input.node node=nxNode attrs=containerAttrs link-attrs=linkAttrs/>
+      </if>
     </marko-web-native-x-render>
   </@slot>
   <if(adIndex !== null)>

--- a/packages/daily/components/nodes/content-card.marko
+++ b/packages/daily/components/nodes/content-card.marko
@@ -5,29 +5,32 @@ $ const hasImage = Boolean(get(input, "node.primaryImage.src"));
 $ const modifiers = [...getAsArray(input, "modifiers"), "content-card"];
 $ if (!hasImage) modifiers.push("zoomed");
 
-<daily-content-list-node
-  node=input.node
-  image-position=defaultValue(input.imagePosition, "top")
-  display-image=defaultValue(input.displayImage, true)
-  flush=defaultValue(input.flush, false)
-  card=true
-  full-height=defaultValue(input.fullHeight, true)
-  attrs=input.attrs
-  link-attrs=input.linkAttrs
-  modifiers=modifiers
-  with-teaser=defaultValue(input.withTeaser, true)
-  with-body=defaultValue(input.withBody, false)
-  with-section=defaultValue(input.withSection, true)
-  with-attribution=defaultValue(input.withAttribution, true)
-  with-dates=defaultValue(input.withDates, true)
-  title=input.title
-  teaser=input.teaser
-  attribution=input.attribution
->
-  <@image
-    ar="16:9"
-    width=340
-    ...input.image
-    fluid=true
-  />
-</daily-content-list-node>
+<!-- @todo Determine a better way to account for if an empty/null node is passed into this-->
+<if(Object.keys(input.node).length)>
+  <daily-content-list-node
+    node=input.node
+    image-position=defaultValue(input.imagePosition, "top")
+    display-image=defaultValue(input.displayImage, true)
+    flush=defaultValue(input.flush, false)
+    card=true
+    full-height=defaultValue(input.fullHeight, true)
+    attrs=input.attrs
+    link-attrs=input.linkAttrs
+    modifiers=modifiers
+    with-teaser=defaultValue(input.withTeaser, true)
+    with-body=defaultValue(input.withBody, false)
+    with-section=defaultValue(input.withSection, true)
+    with-attribution=defaultValue(input.withAttribution, true)
+    with-dates=defaultValue(input.withDates, true)
+    title=input.title
+    teaser=input.teaser
+    attribution=input.attribution
+  >
+    <@image
+      ar="16:9"
+      width=340
+      ...input.image
+      fluid=true
+    />
+  </daily-content-list-node>
+</if>


### PR DESCRIPTION
![Screenshot from 2022-12-13 11-57-30](https://user-images.githubusercontent.com/46794001/207420366-b2046a7b-582d-49c4-b870-5368d0ed6953.png)
![Screenshot from 2022-12-13 12-24-09](https://user-images.githubusercontent.com/46794001/207420368-c9aebcc1-804b-433b-a173-c1dbbbb79934.png)
![Screenshot from 2022-12-13 12-24-21](https://user-images.githubusercontent.com/46794001/207420371-10c73eef-f3eb-4877-8284-0e4628c28ae1.png)
![Screenshot from 2022-12-13 12-24-55](https://user-images.githubusercontent.com/46794001/207420375-21519fb6-65db-4365-91cd-91011e0682aa.png)
![Screenshot from 2022-12-13 12-25-07](https://user-images.githubusercontent.com/46794001/207420376-7a595c07-fc67-41bb-bf52-a7172f7fee22.png)
![Screenshot from 2022-12-13 12-26-25](https://user-images.githubusercontent.com/46794001/207420377-adb49d6a-f25c-4ebf-936a-97ad2ec54e74.png)
![Screenshot from 2022-12-13 12-26-31](https://user-images.githubusercontent.com/46794001/207420381-9a9dd76a-82e8-4d94-95b9-8147b28f38f4.png)
![Screenshot from 2022-12-13 12-47-29](https://user-images.githubusercontent.com/46794001/207420384-fb034fe5-fd32-479c-b8a6-5904c1e6085f.png)
![Screenshot from 2022-12-13 12-48-01](https://user-images.githubusercontent.com/46794001/207420388-ff41d701-d167-4c78-9d94-ef2ce74d1622.png)
![Screenshot from 2022-12-13 12-48-09](https://user-images.githubusercontent.com/46794001/207420390-eb42af71-7cec-446a-8833-ce4c1e2d4660.png)

Tried to provide as many screenshots as possible to demonstrate the outcome here, Ascend (to my knowledge) is aware of the drawbacks of doing this and this seems to be the easiest way to support this feature and could likely be introduce elsewhere to counter the same issue of "where did my content go?"