### PR TITLE
Support fixed position Native-X ads, Correct logic in `package-daily`

### DIFF
--- a/packages/daily/components/blocks/content-featured.marko
+++ b/packages/daily/components/blocks/content-featured.marko
@@ -18,7 +18,7 @@ $ const queryParams = {
 
 <marko-web-query|{ nodes }| name="website-optioned-content" params=queryParams>
   <!-- Native-X here uses base 0 indexing whereas Array.length is defined using base 1 -->
-  $ const slotInNativeX = nxConfig.enabled && (nativeX && nativeX.index);
+  $ const slotInNativeX = nxConfig.enabled && (nativeX && nativeX.index >= 0);
   $ const finalizedNodes =  slotInNativeX ? [
     ...nodes.slice(0, nativeX.index),
     {},

--- a/packages/daily/components/blocks/section-list.marko
+++ b/packages/daily/components/blocks/section-list.marko
@@ -26,7 +26,7 @@ $ const queryParams = {
 
 <marko-web-query|{ nodes, section }| name="website-scheduled-content" params=queryParams>
   <!-- Native-X here uses base 0 indexing whereas Array.length is defined using base 1 -->
-  $ const slotInNativeX = nxConfig.enabled && (nativeX && nativeX.index);
+  $ const slotInNativeX = nxConfig.enabled && (nativeX && nativeX.index >= 0);
   $ const finalizedNodes =  slotInNativeX ? [
     ...nodes.slice(0, nativeX.index),
     {},

--- a/packages/daily/components/flows/content/card-deck.marko
+++ b/packages/daily/components/flows/content/card-deck.marko
@@ -9,7 +9,7 @@ $ const image = getAsObject(input, "node.image");
 $ const nativeX = getAsObject(input, "nativeX");
 
 <!-- Native-X here uses base 0 indexing whereas Array.length uses base 1 -->
-$ const slotInNativeX = nxConfig.enabled && (nativeX && nativeX.index);
+$ const slotInNativeX = nxConfig.enabled && (nativeX && nativeX.index >= 0);
 $ const finalizedNodes = slotInNativeX ? [
   ...nodes.slice(0, nativeX.index),
   {},

--- a/packages/global/components/flows/content/card-deck.marko
+++ b/packages/global/components/flows/content/card-deck.marko
@@ -3,10 +3,17 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { GAM, nativeX: nxConfig } = out.global;
 
-$ const { aliases, adIndex, adName } = input;
+$ const { aliases, adIndex, adName, nodes } = input;
 $ const adPosition = input.adPosition || "after";
 $ const image = getAsObject(input, "node.image");
 $ const nativeX = getAsObject(input, "nativeX");
+
+$ const slotInNativeX = nxConfig.enabled && (nativeX && nativeX.index >= 0);
+$ const finalizedNodes =  slotInNativeX ? [
+  ...nodes.slice(0, nativeX.index),
+  {},
+  ...nodes.slice(nativeX.index, nodes.length)
+] : nodes;
 
 <default-theme-card-deck-flow
   tag=input.tag
@@ -14,15 +21,12 @@ $ const nativeX = getAsObject(input, "nativeX");
   modifiers=input.modifiers
   attrs=input.attrs
   cols=defaultValue(input.cols, 2)
-  nodes=input.nodes
+  nodes=finalizedNodes
 >
   <@slot|{ node, index }|>
-  $ const { secondIndex } = nativeX;
-  $ const loadMulti = (index === nativeX.index || index === secondIndex) && input.pageNumber === 1;
-  $ const loadNativeX = secondIndex ? (loadMulti) : (index === nativeX.index);
     <marko-web-native-x-render|{ node: nxNode, linkAttrs, containerAttrs }|
       ...nativeX
-      when=(loadNativeX)
+      when=(index === nativeX.index)
       node=node
       config=nxConfig
     >

--- a/packages/global/templates/website-section/home.marko
+++ b/packages/global/templates/website-section/home.marko
@@ -31,7 +31,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 8,
+    limit: 7,
     requiresImage: true,
     queryFragment
   },
@@ -64,7 +64,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 4)>
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 3)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
@@ -90,14 +90,14 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </else>
           </div>
         </div>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(4, 6) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(3, 5) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-4 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=1 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 7) cols=1 />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />

--- a/packages/global/templates/website-section/index.marko
+++ b/packages/global/templates/website-section/index.marko
@@ -30,7 +30,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 11,
+    limit: 10,
     requiresImage: true,
     queryFragment
   },
@@ -67,17 +67,17 @@ $ const useNativeXHeroBlock = site.getAsArray("nativeXHeroSections").includes(al
         <else>
           <global-standard-hero-block nodes=getAsArray(featured, "nodes") />-
         </else>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 5) cols=3 ad-index=1 ad-name="rail1" ad-modifiers=["paid"]>
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 4) cols=3 ad-index=1 ad-name="rail1" ad-modifiers=["paid"]>
           <@native-x index=2 name="default" aliases=[section.alias] />
         </global-content-card-deck-flow>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 7) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(4, 6) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 11) cols=2 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 10) cols=2 />
           </div>
         </div>
 

--- a/sites/aadmeetingnews.org/server/templates/website-section/home.marko
+++ b/sites/aadmeetingnews.org/server/templates/website-section/home.marko
@@ -31,7 +31,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 12,
+    limit: 11,
     requiresImage: true,
     queryFragment
   },
@@ -64,7 +64,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 7) ad-index=4 ad-name="rail2">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6) ad-index=4 ad-name="rail2">
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
@@ -82,14 +82,14 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </if>
           </div>
         </div>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 10) cols=3 />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 9) cols=3 />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-4 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(10, 12) cols=1 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(9, 11) cols=1 />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />

--- a/sites/asa.org/server/templates/website-section/home.marko
+++ b/sites/asa.org/server/templates/website-section/home.marko
@@ -31,7 +31,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 10,
+    limit: 9,
     requiresImage: true,
     queryFragment
   },
@@ -64,7 +64,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 5)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
@@ -82,14 +82,14 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </if>
           </div>
         </div>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 7) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-4 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 9) cols=1 />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />

--- a/sites/ashp.org/server/templates/index.marko
+++ b/sites/ashp.org/server/templates/index.marko
@@ -31,7 +31,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 9,
+    limit: 8,
     requiresImage: true,
     queryFragment
   },
@@ -64,7 +64,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 4)>
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 3)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
@@ -91,11 +91,11 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </else>
           </div>
         </div>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(4, 6) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(3, 5) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 9) cols=2 ad-index=0 ad-name="rail3" ad-position="before" />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 8) cols=2 ad-index=0 ad-name="rail3" ad-position="before" />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />

--- a/sites/ashp.org/server/templates/website-section/index.marko
+++ b/sites/ashp.org/server/templates/website-section/index.marko
@@ -30,7 +30,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 12,
+    limit: 11,
     requiresImage: true,
     queryFragment
   },
@@ -60,22 +60,22 @@ $ const promise = websiteSectionContentLoader(apollo, {
       </@above-page>
       <@page>
           <global-standard-hero-block nodes=getAsArray(featured, "nodes") />-
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 5) cols=3 ad-index=1 ad-name="rail1" ad-modifiers=["paid"]>
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 4) cols=3 ad-index=1 ad-name="rail1" ad-modifiers=["paid"]>
           <@native-x index=2 name="default" aliases=[section.alias] />
         </global-content-card-deck-flow>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 7) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(4, 6) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 9) cols=2 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=2 />
           </div>
         </div>
 
         <div class="row">
-          <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(9, 12) cols=3 />
+          <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 11) cols=3 />
         </div>
 
         <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center", "paid"] />

--- a/sites/auadailynews.org/server/templates/website-section/home.marko
+++ b/sites/auadailynews.org/server/templates/website-section/home.marko
@@ -31,7 +31,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 10,
+    limit: 9,
     requiresImage: true,
     queryFragment
   },
@@ -64,7 +64,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 5)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
@@ -82,14 +82,14 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </if>
           </div>
         </div>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 7) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-4 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 9) cols=1 />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />

--- a/sites/isc.hub.heart.org/server/templates/website-section/home.marko
+++ b/sites/isc.hub.heart.org/server/templates/website-section/home.marko
@@ -31,7 +31,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 10,
+    limit: 9,
     requiresImage: true,
     queryFragment
   },
@@ -64,7 +64,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 5)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
@@ -82,14 +82,14 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </if>
           </div>
         </div>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 7) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-4 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+          <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 9) cols=1 />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />

--- a/sites/sessions.hub.heart.org/server/templates/website-section/home.marko
+++ b/sites/sessions.hub.heart.org/server/templates/website-section/home.marko
@@ -31,7 +31,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
   },
   standardParams: {
     optionName: ["Standard"],
-    limit: 10,
+    limit: 9,
     requiresImage: true,
     queryFragment
   },
@@ -64,7 +64,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
         <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
         <div class="row">
           <div class="col-lg-8 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6)>
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 5)>
               <@native-x index=0 name="default" />
             </global-content-card-deck-flow>
           </div>
@@ -82,14 +82,14 @@ $ const promise = websiteSectionContentLoader(apollo, {
             </if>
           </div>
         </div>
-        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 8) cols=3 ad-index=0 ad-name="rail2" />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(5, 7) cols=3 ad-index=0 ad-name="rail2" />
 
         <div class="row">
           <div class="col-lg-4 mb-block">
             <marko-web-gam-display-ad id="gpt-ad-rail3" />
           </div>
           <div class="col-lg-4 mb-block">
-            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(8, 10) cols=1 />
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(7, 9) cols=1 />
           </div>
           <div class="col-lg-4 mb-block">
             <global-twitter-widget-block />


### PR DESCRIPTION
Various screenshots showing impacted home/section pages

![Screenshot from 2022-12-19 15-00-09](https://user-images.githubusercontent.com/46794001/208529080-c407372f-5071-4f63-9cb5-398def1e85be.png)
![Screenshot from 2022-12-19 15-00-31](https://user-images.githubusercontent.com/46794001/208529135-06acd4a7-411d-41ae-a0ae-6ffb5ee262ca.png)
![Screenshot from 2022-12-19 15-08-55](https://user-images.githubusercontent.com/46794001/208529137-82b55af6-13e5-42c3-a28e-65adfdd59be5.png)
![Screenshot from 2022-12-19 15-17-13](https://user-images.githubusercontent.com/46794001/208529139-1c806fbd-4901-4817-a6dc-8a254eecc2b1.png)
![Screenshot from 2022-12-19 15-23-09](https://user-images.githubusercontent.com/46794001/208529140-e4907f5e-f77b-466a-a812-3000b8e84cdc.png)
![Screenshot from 2022-12-19 15-24-46](https://user-images.githubusercontent.com/46794001/208529141-73791823-6d2b-4af1-911e-de0a4efd8978.png)
![Screenshot from 2022-12-19 15-27-27](https://user-images.githubusercontent.com/46794001/208529142-7f8fc638-7c84-48b3-9545-0c84bc8fb0c3.png)
![Screenshot from 2022-12-19 15-29-50](https://user-images.githubusercontent.com/46794001/208529145-617e58e3-e7bc-430e-872c-99f959158aee.png)
![Screenshot from 2022-12-19 15-32-14](https://user-images.githubusercontent.com/46794001/208529146-50566e3f-77dd-4507-8938-9d47c5c0f3bc.png)
![Screenshot from 2022-12-19 15-37-12](https://user-images.githubusercontent.com/46794001/208529147-8ad2f05d-a35c-4ad5-b428-e203456f2416.png)

Not a substitute for spinning all sites using the Global theme and comparing them to their current production versions.