### PR TITLE
Bulletin layout & section header adjustments

### DIFF
--- a/packages/bulletin/templates/content/index.marko
+++ b/packages/bulletin/templates/content/index.marko
@@ -55,13 +55,7 @@ $ const adSlots = ({ aliases }) => ({
             </default-theme-page-contents>
 
             <aside class="col-lg-4 page-rail">
-              <marko-web-resolve|{ resolved }| promise=issuePromise>
-                $ const { issue, issueContent } = resolved;
-                <if(issue)>
-                  <marko-web-gam-display-ad id="gpt-ad-rail3" />
-                  <bulletin-magazine-latest-issue-node card=true flush=false card=false node=issue />
-                </if>
-              </marko-web-resolve>
+              <marko-web-gam-display-ad id="gpt-ad-rail3" />
             </aside>
           </div>
         </@section>

--- a/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
+++ b/sites/bulletin.entnet.org/server/templates/website-section/classifieds.marko
@@ -64,7 +64,7 @@ $ const adSlots = ({ aliases }) => ({
                     aliases=["courses-meetings"]
                     limit=1
                     collapsible=true
-                    title="Featured Courses & Meetings"
+                    title="Featured Courses | Meetings | Other Opportunities"
                     with-teaser=true
                     with-section=false
                     image-position="left"


### PR DESCRIPTION
300x250 ad only in right rail:
<img width="1451" alt="Screen Shot 2023-01-19 at 8 41 29 AM" src="https://user-images.githubusercontent.com/64623209/213471840-7d2f3f81-8be7-4331-9605-5a0d9b71c39b.png">

Section Header:
<img width="1373" alt="Screen Shot 2023-01-19 at 8 34 44 AM" src="https://user-images.githubusercontent.com/64623209/213471848-019b6cc4-5dd0-41fc-981d-686930aeb742.png">
