### PR TITLE
Rework logic for right rail display on Global Theme sites

### DIFF
--- a/packages/global/templates/content/index.marko
+++ b/packages/global/templates/content/index.marko
@@ -26,8 +26,10 @@ $ const displayCompanyHeader = (content) => {
   return false;
 }
 
-$ const restrictedRightRailContentTypes = defaultValue(site.getAsArray("hideRailOnContentTypes"), ["document", "press-release"]);
-$ const showRightRail = (site.get("restrictRightRailDisplay") && restrictedRightRailContentTypes.includes(type)) ? false : true;
+$ const hideRailOnContentTypes = site.getAsArray("hideRailOnContentTypes");
+$ const restrictedRightRailContentTypes = hideRailOnContentTypes.length ? hideRailOnContentTypes : ["document", "press-release"];
+$ const showRightRail = restrictedRightRailContentTypes.includes(type) ? false : true;
+$ const showRailAds = hideRailOnContentTypes.length ? false : true;
 
 <marko-web-content-page-layout id=id type=type>
   <@head>
@@ -126,7 +128,7 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && restrictedRight
                 />
               </else-if>
               <else-if(type === "media-gallery")>
-                <marko-web-image-slider 
+                <marko-web-image-slider
                   images=getAsArray(content, "images.edges").map(edge => edge.node)
                   image-options={ fit: "crop", w: 800, h: 450, auto: "format,compress" }
                 />
@@ -219,6 +221,16 @@ $ const showRightRail = (site.get("restrictRightRailDisplay") && restrictedRight
               </if>
               <else-if(showRightRail)>
                 <global-right-rail-block aliases=aliases no-shadow=true />
+              </else-if>
+              <else-if(showRailAds)>
+                <marko-web-gam-define-display-ad
+                  ...GAM.getAdUnit({ name: "rail1", aliases })
+                  class="mb-block"
+                />
+                <marko-web-gam-define-display-ad
+                  ...GAM.getAdUnit({ name: "rail2", aliases })
+                  class="mb-block"
+                />
               </else-if>
             </aside>
 

--- a/sites/aadmeetingnews.org/config/site.js
+++ b/sites/aadmeetingnews.org/config/site.js
@@ -9,7 +9,6 @@ module.exports = {
     limit: 9,
     sectionName: 'Presented by',
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   contentPageLoadMoreSettings: {
     restrictedOn: ['press-release'],

--- a/sites/aao.hns.org/config/site.js
+++ b/sites/aao.hns.org/config/site.js
@@ -7,7 +7,6 @@ module.exports = {
   nativeXBlock: {
     enabled: Boolean(process.env.NATIVE_X_BLOCK),
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,
   navigation,

--- a/sites/acep.org/config/site.js
+++ b/sites/acep.org/config/site.js
@@ -8,7 +8,6 @@ module.exports = {
     enabled: Boolean(process.env.NATIVE_X_BLOCK),
     title: 'ACEP22 Newsroom',
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,
   navigation,

--- a/sites/asa.org/config/site.js
+++ b/sites/asa.org/config/site.js
@@ -9,7 +9,6 @@ module.exports = {
     title: 'From The ASA Monitor',
     withSection: false,
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   searchTitle: 'Search Annual Meeting Daily News',
   logos,

--- a/sites/ashp.org/config/site.js
+++ b/sites/ashp.org/config/site.js
@@ -8,7 +8,6 @@ module.exports = {
     enabled: Boolean(process.env.NATIVE_X_BLOCK),
     title: 'Featured Stories',
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,
   navigation,

--- a/sites/auadailynews.org/config/site.js
+++ b/sites/auadailynews.org/config/site.js
@@ -7,7 +7,6 @@ module.exports = {
   nativeXBlock: {
     enabled: Boolean(process.env.NATIVE_X_BLOCK),
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,
   navigation,

--- a/sites/isc.hub.heart.org/config/site.js
+++ b/sites/isc.hub.heart.org/config/site.js
@@ -7,7 +7,6 @@ module.exports = {
   nativeXBlock: {
     enabled: Boolean(process.env.NATIVE_X_BLOCK),
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,
   navigation,

--- a/sites/sessions.hub.heart.org/config/site.js
+++ b/sites/sessions.hub.heart.org/config/site.js
@@ -8,7 +8,6 @@ module.exports = {
   nativeXBlock: {
     enabled: Boolean(process.env.NATIVE_X_BLOCK),
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   blocks,
   logos,

--- a/sites/shm.org/config/site.js
+++ b/sites/shm.org/config/site.js
@@ -7,7 +7,6 @@ module.exports = {
   nativeXBlock: {
     enabled: Boolean(process.env.NATIVE_X_BLOCK),
   },
-  restrictRightRailDisplay: Boolean(process.env.RESTRICT_RIGHT_RAIL_DISPLAY),
   contentPageLoadMore: Boolean(process.env.CONTENT_PAGE_LOAD_MORE),
   logos,
   navigation,


### PR DESCRIPTION
This is namely to exclude it on Press Releases and Documents across all sites.