### PR TITLE
Add ‘og:image’ meta tag for social sharing

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -10,8 +10,6 @@ $ const aboveContainer = get(input, "aboveContainer.renderBody");
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
-    <meta property="og:image:width" content="1200"/>
-    <meta property="og:image:height" content="630"/>
     <marko-web-deferred-script-loader-init />
     <marko-web-p1-events-init
       on="load"

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -10,6 +10,8 @@ $ const aboveContainer = get(input, "aboveContainer.renderBody");
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
+    <meta property="og:image:width" content="1200"/>
+    <meta property="og:image:height" content="630"/>
     <marko-web-deferred-script-loader-init />
     <marko-web-p1-events-init
       on="load"

--- a/sites/shm.org/server/templates/website-section/home.marko
+++ b/sites/shm.org/server/templates/website-section/home.marko
@@ -49,6 +49,8 @@ $ const promise = websiteSectionContentLoader(apollo, {
           <marko-web-gtm-push data=context />
         </marko-web-gtm-website-section-context>
         <marko-web-gam-slots slots=slots />
+        <meta property="og:image:width" content="1200"/>
+        <meta property="og:image:height" content="630"/>
       </@head>
 
       <@above-page>


### PR DESCRIPTION
Edit:
Homepage:
<img width="1788" alt="Screen Shot 2023-03-09 at 10 52 58 AM" src="https://user-images.githubusercontent.com/64623209/224099559-ee28808a-f0d1-4fb6-9842-cef40669e741.png">
Content Page:
<img width="1791" alt="Screen Shot 2023-03-09 at 10 53 58 AM" src="https://user-images.githubusercontent.com/64623209/224099563-52778492-087e-4929-b588-bc42e00e65d6.png">

Not sure how to test this but from what I researched:
https://developers.facebook.com/docs/sharing/webmasters/images/
adding this tag will resize the image when sharing on social media