### PR TITLE
Add Interesting Stories block to Daily Coverage Channel, AAD.

### DIFF
--- a/packages/global/templates/website-section/interesting-stories.marko
+++ b/packages/global/templates/website-section/interesting-stories.marko
@@ -1,0 +1,124 @@
+import { get, getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { isFunction } from "@parameter1/base-cms-utils";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import websiteSectionContentLoader from "@ascend-media/package-global/loaders/website-section-content";
+import queryFragment from "@ascend-media/package-global/graphql/fragments/content-list";
+
+$ const { GAM, apollo, site } = out.global;
+$ const nativeXBlock = site.getAsObject("nativeXBlock");
+
+$ const {
+  id,
+  alias,
+  name,
+  pageNode,
+} = input;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2": GAM.getAdUnit({ name: "lb2", aliases }),
+  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail3", size:[300, 600],  aliases }),
+});
+
+$ const promise = websiteSectionContentLoader(apollo, {
+  sectionId: id,
+  featuredParams: {
+    optionName: ["Pinned"],
+    limit: 5,
+    requiresImage: true,
+    queryFragment
+  },
+  standardParams: {
+    optionName: ["Standard"],
+    limit: 10,
+    requiresImage: true,
+    queryFragment
+  },
+  withStandardQuery: true,
+});
+
+<marko-web-resolve|{ resolved: sectionContent }| promise=promise>
+  $ const { featured, standard } = sectionContent;
+  <marko-web-resolve|{ resolved: { data: section } }| promise=pageNode.load()>
+    $ const aliases = hierarchyAliases(section);
+    $ const slots = adSlots({ aliases });
+    <marko-web-website-section-page-layout id=id alias=alias name=name attrs={"aria-label": `website-section-${id}`}>
+      <@head>
+        <marko-web-gtm-website-section-context|{ context }| alias=alias>
+          <marko-web-gtm-push data=context />
+        </marko-web-gtm-website-section-context>
+        <marko-web-gam-slots slots=slots />
+      </@head>
+
+      <@above-page>
+        <marko-web-gam-display-ad
+          id="gpt-ad-lb1"
+          slots=slots
+          class="mt-block"
+          modifiers=["max-width-970", "margin-auto-x", "center", "paid"]
+        />
+      </@above-page>
+      <@page>
+        <global-standard-hero-block nodes=getAsArray(featured, "nodes") />
+        <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(0, 2) cols=3 ad-index=1 ad-name="rail1" />
+        <div class="row">
+          <div class="col-lg-8 mb-block">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(2, 6) ad-index=2 ad-name="rail2">
+              <@native-x index=0 name="default" />
+            </global-content-card-deck-flow>
+          </div>
+          <div class="col-lg-4 mb-block">
+            <if(nativeXBlock && nativeXBlock.enabled)>
+              $ const { limit, title, sectionName, withSection } = nativeXBlock;
+              <global-native-x-list-block
+                placement-name="default"
+                aliases=aliases
+                limit=limit
+                collapsible=true
+                title=title
+                with-section=withSection
+                section-name=sectionName
+              />
+            </if>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-lg-4 mb-block">
+            <marko-web-gam-display-ad id="gpt-ad-rail3" />
+          </div>
+          <div class="col-lg-8 mb-block">
+            <global-content-card-deck-flow nodes=getAsArray(standard, "nodes").slice(6, 10) cols=2 />
+          </div>
+        </div>
+
+        <marko-web-gam-display-ad id="gpt-ad-lb2" modifiers=["max-width-790", "center", "paid"] />
+
+      </@page>
+
+      <@below-page>
+        <marko-web-resolve-page|{ data: section }| node=pageNode>
+          $ const aliases = hierarchyAliases(section);
+          $ const loadMoreParams = {
+            sectionId: id,
+            optionName: ["Standard"],
+            excludeContentIds: sectionContent.ids,
+            limit: 12,
+          };
+          <marko-web-load-more
+            component-name="global-content-card-deck-flow"
+            component-input={ aliases, cols: 3, withTeaser: false, adName: 'load-more', adIndex: 0 }
+            fragment-name="global-content-list"
+            query-name="website-scheduled-content"
+            query-params=loadMoreParams
+            max-pages=3
+            page-input={ for: "website-section", id }
+            attrs={ "aria-label": "load-more", "role": "main" }
+          />
+        </marko-web-resolve-page>
+      </@below-page>
+
+    </marko-web-website-section-page-layout>
+  </marko-web-resolve>
+</marko-web-resolve>

--- a/sites/aadmeetingnews.org/server/routes/website-section/index.js
+++ b/sites/aadmeetingnews.org/server/routes/website-section/index.js
@@ -3,6 +3,7 @@ const queryFragment = require('@ascend-media/package-global/graphql/fragments/we
 const section = require('@ascend-media/package-global/templates/website-section');
 const exhibitors = require('@ascend-media/package-global/templates/website-section/exhibitors');
 const nativeX = require('@ascend-media/package-global/templates/website-section/native-x');
+const interestingStories = require('@ascend-media/package-global/templates/website-section/interesting-stories');
 
 module.exports = (app) => {
   app.get('/:alias(industry-highlights)', withWebsiteSection({
@@ -12,6 +13,11 @@ module.exports = (app) => {
 
   app.get('/:alias(small-exhibit-spotlight)', withWebsiteSection({
     template: exhibitors,
+    queryFragment,
+  }));
+
+  app.get('/:alias(daily-coverage)', withWebsiteSection({
+    template: interestingStories,
     queryFragment,
   }));
 


### PR DESCRIPTION
PROD:
![Screenshot from 2023-03-13 15-14-41](https://user-images.githubusercontent.com/46794001/224822317-b9bb30eb-ddf0-42b2-a5f8-288fefbb2bf8.png)

DEV:
![Screenshot from 2023-03-13 15-14-25](https://user-images.githubusercontent.com/46794001/224822328-350d478b-007d-49ae-a919-48ac22c8e883.png)


This preserves the existing page layout with the ad placements unmoved other than where required (the 300x600 tower ad) and places the Interesting Stories block in the appropriate location.