### PR TITLE
If content type is `Page` don’t load `@below-page` contents

### DIFF
--- a/packages/global-monorail/components/layouts/content/wrapper.marko
+++ b/packages/global-monorail/components/layouts/content/wrapper.marko
@@ -51,22 +51,24 @@ $ const alias = get(input, "primarySection.alias");
     </marko-web-resolve-page>
   </@page>
   <@below-page>
-    <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
-      <!-- Refresh sticky, right-rail infinite scroll ad -->
-      <!-- <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" /> -->
+    <if(type !== "page")>
+      <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
+        <!-- Refresh sticky, right-rail infinite scroll ad -->
+        <!-- <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" /> -->
 
-      <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
-        $ const section = content.primarySection;
-        <marko-web-page-wrapper>
-          <@section|{ aliases }|>
-            <global-section-feed-wrapper aliases=aliases alias=section.alias>
-              <@header>More in ${section.name}</@header>
-              <@query-params excludeContentIds=[content.id] />
-            </global-section-feed-wrapper>
-          </@section>
-        </marko-web-page-wrapper>
-      </marko-web-resolve-page>
-    </marko-web-page-container>
+        <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+          $ const section = content.primarySection;
+          <marko-web-page-wrapper>
+            <@section|{ aliases }|>
+              <global-section-feed-wrapper aliases=aliases alias=section.alias>
+                <@header>More in ${section.name}</@header>
+                <@query-params excludeContentIds=[content.id] />
+              </global-section-feed-wrapper>
+            </@section>
+          </marko-web-page-wrapper>
+        </marko-web-resolve-page>
+      </marko-web-page-container>
+    </if>
   </@below-page>
   <@foot>
     <marko-web-resolve-page|{ data: content }| node=pageNode>

--- a/packages/global-monorail/components/layouts/content/wrapper.marko
+++ b/packages/global-monorail/components/layouts/content/wrapper.marko
@@ -51,24 +51,22 @@ $ const alias = get(input, "primarySection.alias");
     </marko-web-resolve-page>
   </@page>
   <@below-page>
-    <if(type !== "page")>
-      <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
-        <!-- Refresh sticky, right-rail infinite scroll ad -->
-        <!-- <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" /> -->
+    <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
+      <!-- Refresh sticky, right-rail infinite scroll ad -->
+      <!-- <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" /> -->
 
-        <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
-          $ const section = content.primarySection;
-          <marko-web-page-wrapper>
-            <@section|{ aliases }|>
-              <global-section-feed-wrapper aliases=aliases alias=section.alias>
-                <@header>More in ${section.name}</@header>
-                <@query-params excludeContentIds=[content.id] />
-              </global-section-feed-wrapper>
-            </@section>
-          </marko-web-page-wrapper>
-        </marko-web-resolve-page>
-      </marko-web-page-container>
-    </if>
+      <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+        $ const section = content.primarySection;
+        <marko-web-page-wrapper>
+          <@section|{ aliases }|>
+            <global-section-feed-wrapper aliases=aliases alias=section.alias>
+              <@header>More in ${section.name}</@header>
+              <@query-params excludeContentIds=[content.id] />
+            </global-section-feed-wrapper>
+          </@section>
+        </marko-web-page-wrapper>
+      </marko-web-resolve-page>
+    </marko-web-page-container>
   </@below-page>
   <@foot>
     <marko-web-resolve-page|{ data: content }| node=pageNode>

--- a/packages/global-monorail/components/layouts/content/wrapper.marko
+++ b/packages/global-monorail/components/layouts/content/wrapper.marko
@@ -50,7 +50,7 @@ $ const alias = get(input, "primarySection.alias");
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
-  <if(type!== "page")>
+  <if(type !== "page")>
     <@below-page>
       <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
         <!-- Refresh sticky, right-rail infinite scroll ad -->

--- a/packages/global-monorail/components/layouts/content/wrapper.marko
+++ b/packages/global-monorail/components/layouts/content/wrapper.marko
@@ -50,24 +50,26 @@ $ const alias = get(input, "primarySection.alias");
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
-  <@below-page>
-    <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
-      <!-- Refresh sticky, right-rail infinite scroll ad -->
-      <!-- <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" /> -->
+  <if(type!== "page")>
+    <@below-page>
+      <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
+        <!-- Refresh sticky, right-rail infinite scroll ad -->
+        <!-- <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" /> -->
 
-      <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
-        $ const section = content.primarySection;
-        <marko-web-page-wrapper>
-          <@section|{ aliases }|>
-            <global-section-feed-wrapper aliases=aliases alias=section.alias>
-              <@header>More in ${section.name}</@header>
-              <@query-params excludeContentIds=[content.id] />
-            </global-section-feed-wrapper>
-          </@section>
-        </marko-web-page-wrapper>
-      </marko-web-resolve-page>
-    </marko-web-page-container>
-  </@below-page>
+        <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+          $ const section = content.primarySection;
+          <marko-web-page-wrapper>
+            <@section|{ aliases }|>
+              <global-section-feed-wrapper aliases=aliases alias=section.alias>
+                <@header>More in ${section.name}</@header>
+                <@query-params excludeContentIds=[content.id] />
+              </global-section-feed-wrapper>
+            </@section>
+          </marko-web-page-wrapper>
+        </marko-web-resolve-page>
+      </marko-web-page-container>
+    </@below-page>
+  </if>
   <@foot>
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       <theme-fixed-ad-bottom aliases=hierarchyAliases(content.primarySection) />

--- a/packages/global-monorail/templates/dynamic-page/index.marko
+++ b/packages/global-monorail/templates/dynamic-page/index.marko
@@ -1,52 +1,38 @@
-import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
-import { getAsArray, get } from "@parameter1/base-cms-object-path";
-
 $ const { id, type, pageNode } = input;
 
-<theme-content-page id=id type=type >
-  <@head>
-    <marko-web-gtm-content-context|{ context }| id=id>
-      <marko-web-gtm-push data=context />
-    </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      <marko-web-p1-events-track-content node=content />
-    </marko-web-resolve-page>
-  </@head>
-  <@page>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      $ const aliases = hierarchyAliases(content.primarySection);
-      <marko-web-page-wrapper>
-        <@section|{ aliases }| modifiers=["first"]>
-          <theme-gam-define-display-ad
-            name="leaderboard"
-            position="content_page"
-            aliases=aliases
-            modifiers=["inter-block"]
-          />
-        </@section>
-        <@section|{ blockName }|>
-          $ const { primarySection } = content;
-          <div class="content-page-header">
-            <theme-content-page-breadcrumbs section=primarySection />
-            <marko-web-content-name tag="h1" block-name=blockName obj=content />
-          </div>
-        </@section>
+<global-content-wrapper-layout
+  id=id
+  type=type
+  page-node=pageNode
+>
 
-        <@section|{ blockName }|>
-          <div class="row">
-            <div class="col-lg-8">
-              <div class="content-page-body">
-                <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
+  <@section|{ aliases }| modifiers=["first"]>
+    <theme-gam-define-display-ad
+      name="leaderboard"
+      position="content_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
 
-                  $ const bodyId = `content-body-${content.id}`;
-                  <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
+  <@section|{ blockName, content }|>
+    $ const { primarySection } = content;
+    <div class="content-page-header">
+      <theme-content-page-breadcrumbs section=primarySection />
+      <marko-web-content-name tag="h1" block-name=blockName obj=content />
+    </div>
+  </@section>
 
-                </theme-page-contents>
-              </div>
-            </div>
-          </div>
-        </@section>
-      </marko-web-page-wrapper>
-    </marko-web-resolve-page>
-  </@page>
-</theme-content-page>
+  <@section|{ blockName, content }|>
+    $ const { primarySection } = content;
+    <div class="content-page-body">
+      <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
+
+        $ const bodyId = `content-body-${content.id}`;
+        <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
+
+      </default-theme-page-contents>
+    </div>
+  </@section>
+
+</global-content-wrapper-layout>

--- a/packages/global-monorail/templates/dynamic-page/index.marko
+++ b/packages/global-monorail/templates/dynamic-page/index.marko
@@ -1,38 +1,52 @@
+import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-aliases";
+import { getAsArray, get } from "@parameter1/base-cms-object-path";
+
 $ const { id, type, pageNode } = input;
 
-<global-content-wrapper-layout
-  id=id
-  type=type
-  page-node=pageNode
->
+<theme-content-page id=id type=type >
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-p1-events-track-content node=content />
+    </marko-web-resolve-page>
+  </@head>
+  <@page>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-page-wrapper>
+        <@section|{ aliases }| modifiers=["first"]>
+          <theme-gam-define-display-ad
+            name="leaderboard"
+            position="content_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </@section>
+        <@section|{ blockName }|>
+          $ const { primarySection } = content;
+          <div class="content-page-header">
+            <theme-content-page-breadcrumbs section=primarySection />
+            <marko-web-content-name tag="h1" block-name=blockName obj=content />
+          </div>
+        </@section>
 
-  <@section|{ aliases }| modifiers=["first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section>
+        <@section|{ blockName }|>
+          <div class="row">
+            <div class="col-lg-8">
+              <div class="content-page-body">
+                <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
 
-  <@section|{ blockName, content }|>
-    $ const { primarySection } = content;
-    <div class="content-page-header">
-      <theme-content-page-breadcrumbs section=primarySection />
-      <marko-web-content-name tag="h1" block-name=blockName obj=content />
-    </div>
-  </@section>
+                  $ const bodyId = `content-body-${content.id}`;
+                  <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
 
-  <@section|{ blockName, content }|>
-    $ const { primarySection } = content;
-    <div class="content-page-body">
-      <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
-
-        $ const bodyId = `content-body-${content.id}`;
-        <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
-
-      </default-theme-page-contents>
-    </div>
-  </@section>
-
-</global-content-wrapper-layout>
+                </theme-page-contents>
+              </div>
+            </div>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</theme-content-page>


### PR DESCRIPTION
Layout of body copy is centered
<img width="1439" alt="Screen Shot 2023-05-02 at 3 01 44 PM" src="https://user-images.githubusercontent.com/64623209/235773343-a36e8a00-5114-461f-9510-1687abf58484.png">

VS

Contact us page (left justified)
<img width="1388" alt="Screen Shot 2023-05-03 at 12 51 03 PM" src="https://user-images.githubusercontent.com/64623209/236002742-c90adb47-7184-40e0-bb10-4acf8e475722.png">

