### PR TITLE
Update More In and Section feed block for Native-X ad serving

### DIFF
--- a/packages/global-monorail/components/wrappers/section-feed.marko
+++ b/packages/global-monorail/components/wrappers/section-feed.marko
@@ -1,6 +1,10 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import convertAdToContent from "@parameter1/base-cms-marko-web-native-x/utils/convert-ad-to-content";
+import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/section-feed-block";
 
-$ const { pagination: p } = out.global;
+$ const { nativeX: nxConfig, pagination: p } = out.global;
+$ const uri = nxConfig.getUri();
+$ const placement = nxConfig.getPlacement({ name: "default", aliases: input.aliases });
 $ const perPage = 12;
 $ const withPagination = defaultValue(input.withPagination, true);
 $ const { modifiers } = input;
@@ -9,54 +13,37 @@ $ const queryParams = {
   ...input.queryParams,
 };
 
+$ const queryParamsWithPagination = {
+  ...queryParams,
+  limit: perPage,
+  skip: p.skip({ perPage }),
+  queryFragment
+};
 <div class="row">
   <div class="col-lg-8">
-    <theme-section-feed-block
-      alias=input.alias
-      header=input.header
-      modifiers=modifiers
-    >
-      <@query-params ...queryParams limit=3 skip=p.skip({ perPage })/>
-      <@node-list innerJustified=false ...input.nodeList />
-    </theme-section-feed-block>
-    <theme-gam-define-display-ad
-      name="inline-content-desktop"
-      position="section_page"
-      aliases=input.aliases
-      modifiers=["inline-section-feed"]
-    />
-    <theme-section-feed-block alias=input.alias modifiers=modifiers>
-      <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 3 }) />
-      <@node-list innerJustified=false ...input.nodeList />
-    </theme-section-feed-block>
-    <theme-gam-define-display-ad
-      name="inline-content-desktop"
-      position="section_page"
-      aliases=input.aliases
-      modifiers=["inline-section-feed"]
-    />
-  </div>
-  <div class="col-lg-4">
-    <global-most-popular-list-block class="sticky-top" />
-  </div>
-</div>
-<div class="row">
-  <div class="col-lg-8">
-    <theme-section-feed-block alias=input.alias modifiers=modifiers>
-      <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 6 }) />
-      <@node-list innerJustified=false ...input.nodeList />
-    </theme-section-feed-block>
-    <!--   -->
-    <theme-gam-define-display-ad
-      name="inline-content-desktop"
-      position="section_page"
-      aliases=input.aliases
-      modifiers=["inline-section-feed"]
-    />
-    <theme-section-feed-block alias=input.alias modifiers=modifiers>
-      <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 9 }) />
-      <@node-list innerJustified=false ...input.nodeList />
-    </theme-section-feed-block>
+    <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParamsWithPagination>
+      $ const nodesWithAds = [
+        ...nodes.slice(0,3),
+        {},
+        ...nodes.slice(3,6),
+        {},
+        ...nodes.slice(6,9),
+        {},
+        ...nodes.slice(9)
+      ];
+      $ const nodeList = { innerJustified: false, ...input.nodeList };
+      <theme-section-feed-flow
+        nodes=nodesWithAds
+        header=input.header
+        node=input.node
+        node-list=nodeList
+        display-image=true
+        with-section=true
+        modifiers=input.modifiers
+        native-x={ indexes: [3, 7, 11], name: "default", aliases: input.aliases }
+        with-native-x-section=input.withNativeXSection
+      />
+    </marko-web-query>
     <if(withPagination)>
       <theme-section-feed-block|{ totalCount }| alias=input.alias count-only=true>
         <@query-params ...queryParams />
@@ -69,6 +56,6 @@ $ const queryParams = {
     </if>
   </div>
   <div class="col-lg-4">
-    <!-- <global-most-popular-list-block class="sticky-top" /> -->
+    <global-most-popular-list-block class="sticky-top" />
   </div>
 </div>


### PR DESCRIPTION
Section Page:
![Screenshot from 2023-05-03 10-02-54](https://user-images.githubusercontent.com/46794001/235960487-561b6ba2-15cc-4ded-af77-f89ffdef0617.png)

More In:
![Screenshot from 2023-05-03 10-10-21](https://user-images.githubusercontent.com/46794001/235960496-a84cc250-ee3c-4395-98aa-9079a81644ec.png)

What happens if a Native Ad isn't returned:
![Screenshot from 2023-05-03 10-17-52](https://user-images.githubusercontent.com/46794001/235960497-11142ac0-674e-49fb-8150-2e166f5121a5.png)
