### PR TITLE
Remove GAM ad, sticky interesting stories block in right rail on media gallery content page

### DIFF
--- a/packages/global/scss/theme.scss
+++ b/packages/global/scss/theme.scss
@@ -7,7 +7,7 @@ $pswp__root-z-index: $theme-site-header-z-index + 1 !default;
 @import "@parameter1/base-cms-marko-web-photoswipe/scss/main";
 @import "@parameter1/base-cms-marko-web-social-sharing/scss/buttons";
 @import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
-
+@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/sticky-top";
 // vue-modal styles
 @import "./components/vue-modal";
 
@@ -64,4 +64,8 @@ $pswp__root-z-index: $theme-site-header-z-index + 1 !default;
       border-bottom: none;
     }
   }
+}
+
+.sticky-top {
+  top: 175px;
 }

--- a/packages/global/templates/content/media-gallery.marko
+++ b/packages/global/templates/content/media-gallery.marko
@@ -89,7 +89,24 @@ $ const displaySocialShare = ["contact"].includes(type) ? false : true;
               <marko-web-content-sidebars block-name=blockName obj=content />
             </default-theme-page-contents>
             <aside class="col-lg-4 page-rail">
-              <global-right-rail-block aliases=aliases no-shadow=true />
+              <div class="sticky-top">
+                $ const nativeXBlock = site.getAsObject("nativeXBlock");
+                $ const { limit, title, sectionName, withSection } = nativeXBlock;
+                <global-native-x-list-block
+                  placement-name="default"
+                  aliases=aliases
+                  limit=limit
+                  collapsible=true
+                  title=title
+                  with-section=withSection
+                  section-name=sectionName
+                />
+
+                <marko-web-gam-define-display-ad
+                ...GAM.getAdUnit({ name: "rail2", aliases })
+                  class="mb-block"
+                />
+              </div>
             </aside>
           </div>
         </@section>


### PR DESCRIPTION
<img width="1678" alt="Screen Shot 2023-07-14 at 1 33 57 PM" src="https://github.com/parameter1/ascend-media-websites/assets/64623209/20d58e01-4686-40ac-927e-615c1e62ab0e">
<img width="1515" alt="Screen Shot 2023-07-14 at 1 34 06 PM" src="https://github.com/parameter1/ascend-media-websites/assets/64623209/fca89dc7-f47b-4ea8-825f-7c6e90c69931">
