### PR TITLE
Allow for ‘Promotions’ on exhibitors pages

### DIFF
--- a/packages/global/components/blocks/exhibitors.marko
+++ b/packages/global/components/blocks/exhibitors.marko
@@ -9,7 +9,7 @@ $ const queryParams = {
   queryFragment,
   sectionBubbling: false,
   requiresImage: true,
-  includeContentTypes: ["Company"],
+  includeContentTypes: ["Promotion", "Company"],
   ...getAsObject(input, "queryParams"),
   sectionAlias,
 };


### PR DESCRIPTION
<img width="1382" alt="Screen Shot 2023-07-20 at 7 48 09 AM" src="https://github.com/parameter1/ascend-media-websites/assets/64623209/04f12158-5384-4453-9328-58be3e8c4f78">
<img width="1321" alt="Screen Shot 2023-07-20 at 7 48 02 AM" src="https://github.com/parameter1/ascend-media-websites/assets/64623209/4ba3404d-dc82-4e16-b965-21a1486b8f40">
