### PR TITLE
Use of Gallery style page for `/page/awards` and matching page aliases

### DIFF
--- a/packages/daily/graphql/fragments/gallery-style-page.js
+++ b/packages/daily/graphql/fragments/gallery-style-page.js
@@ -1,0 +1,22 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment DynamicPageFragment on ContentPage {
+  id
+  name
+  teaser(input: { useFallback: false, maxLength: null })
+  images(input: { pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src
+        alt
+        displayName
+        caption
+        credit
+        isLogo
+      }
+    }
+  }
+}
+`;

--- a/packages/daily/templates/dynamic-page/gallery-style.marko
+++ b/packages/daily/templates/dynamic-page/gallery-style.marko
@@ -1,0 +1,46 @@
+import { getAsArray, getAsObject, get } from "@parameter1/base-cms-object-path";
+
+$ const { GAM } = out.global;
+
+$ const { id, alias, pageNode } = data;
+
+<marko-web-dynamic-page-layout id=id alias=alias>
+  <@head>
+    <marko-web-gtm-dynamic-page-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-dynamic-page-context>
+  </@head>
+
+  <@page>
+    <marko-web-gam-define-display-ad
+      ...GAM.getAdUnit({ name: "lb1" })
+      class="mt-block"
+      modifiers=["max-width-970", "top-of-page", "center"]
+    />
+
+    <marko-web-resolve-page|{ data: page }| node=pageNode>
+      <marko-web-page-wrapper class="mt-block">
+        <@section>
+          <div class="row">
+            <div class="col">
+              <h1 class="page-wrapper__title">${page.name}</h1>
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=page />
+              <hr>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+          $ const imageNodes = getAsArray(page, "images.edges").map(edge => edge.node);
+          <for|imageNode| of=imageNodes>
+            <div class="col-md-4 col-lg-3">
+              <img src=imageNode.src alt=imageNode.alt width="100%" height="75%" />
+              <span class="caption">$!{imageNode.caption}</span>
+            </div>
+          </for>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-dynamic-page-layout>

--- a/packages/global-monorail/graphql/fragments/gallery-style-page.js
+++ b/packages/global-monorail/graphql/fragments/gallery-style-page.js
@@ -1,0 +1,22 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment DynamicPageFragment on ContentPage {
+  id
+  name
+  teaser(input: { useFallback: false, maxLength: null })
+  images(input: { pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src
+        alt
+        displayName
+        caption
+        credit
+        isLogo
+      }
+    }
+  }
+}
+`;

--- a/packages/global-monorail/templates/dynamic-page/gallery-style.marko
+++ b/packages/global-monorail/templates/dynamic-page/gallery-style.marko
@@ -1,0 +1,46 @@
+import { getAsArray, getAsObject, get } from "@parameter1/base-cms-object-path";
+
+$ const { GAM } = out.global;
+
+$ const { id, alias, pageNode } = data;
+
+<marko-web-dynamic-page-layout id=id alias=alias>
+  <@head>
+    <marko-web-gtm-dynamic-page-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-dynamic-page-context>
+  </@head>
+
+  <@page>
+    <marko-web-gam-define-display-ad
+      ...GAM.getAdUnit({ name: "lb1" })
+      class="mt-block"
+      modifiers=["max-width-970", "top-of-page", "center"]
+    />
+
+    <marko-web-resolve-page|{ data: page }| node=pageNode>
+      <marko-web-page-wrapper class="mt-block">
+        <@section>
+          <div class="row">
+            <div class="col">
+              <h1 class="page-wrapper__title">${page.name}</h1>
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=page />
+              <hr>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+          $ const imageNodes = getAsArray(page, "images.edges").map(edge => edge.node);
+          <for|imageNode| of=imageNodes>
+            <div class="col-md-4 col-lg-3">
+              <img src=imageNode.src alt=imageNode.alt width="100%" height="75%" />
+              <span class="caption">$!{imageNode.caption}</span>
+            </div>
+          </for>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-dynamic-page-layout>

--- a/packages/global/graphql/fragments/gallery-style-page.js
+++ b/packages/global/graphql/fragments/gallery-style-page.js
@@ -1,0 +1,22 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment DynamicPageFragment on ContentPage {
+  id
+  name
+  teaser(input: { useFallback: false, maxLength: null })
+  images(input: { pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src
+        alt
+        displayName
+        caption
+        credit
+        isLogo
+      }
+    }
+  }
+}
+`;

--- a/packages/global/templates/dynamic-page/gallery-style.marko
+++ b/packages/global/templates/dynamic-page/gallery-style.marko
@@ -19,7 +19,6 @@ $ const { id, alias, pageNode } = data;
     />
 
     <marko-web-resolve-page|{ data: page }| node=pageNode>
-      $ console.log(page);
       <marko-web-page-wrapper class="mt-block">
         <@section>
           <div class="row">

--- a/packages/global/templates/dynamic-page/gallery-style.marko
+++ b/packages/global/templates/dynamic-page/gallery-style.marko
@@ -34,7 +34,7 @@ $ const { id, alias, pageNode } = data;
           <div class="row">
           $ const imageNodes = getAsArray(page, "images.edges").map(edge => edge.node);
           <for|imageNode| of=imageNodes>
-            <div class="col-lg-3">
+            <div class="col-md-4 col-lg-3">
               <img src=imageNode.src alt=imageNode.alt width="100%" height="75%" />
               <span class="caption">$!{imageNode.caption}</span>
             </div>

--- a/packages/global/templates/dynamic-page/gallery-style.marko
+++ b/packages/global/templates/dynamic-page/gallery-style.marko
@@ -1,0 +1,47 @@
+import { getAsArray, getAsObject, get } from "@parameter1/base-cms-object-path";
+
+$ const { GAM } = out.global;
+
+$ const { id, alias, pageNode } = data;
+
+<marko-web-dynamic-page-layout id=id alias=alias>
+  <@head>
+    <marko-web-gtm-dynamic-page-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-dynamic-page-context>
+  </@head>
+
+  <@page>
+    <marko-web-gam-define-display-ad
+      ...GAM.getAdUnit({ name: "lb1" })
+      class="mt-block"
+      modifiers=["max-width-970", "top-of-page", "center"]
+    />
+
+    <marko-web-resolve-page|{ data: page }| node=pageNode>
+      $ console.log(page);
+      <marko-web-page-wrapper class="mt-block">
+        <@section>
+          <div class="row">
+            <div class="col">
+              <h1 class="page-wrapper__title">${page.name}</h1>
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=page />
+              <hr>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+          $ const imageNodes = getAsArray(page, "images.edges").map(edge => edge.node);
+          <for|imageNode| of=imageNodes>
+            <div class="col-lg-3">
+              <img src=imageNode.src alt=imageNode.alt width="100%" height="75%" />
+              <span class="caption">$!{imageNode.caption}</span>
+            </div>
+          </for>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-dynamic-page-layout>

--- a/sites/aadmeetingnews.org/server/routes/dynamic-page.js
+++ b/sites/aadmeetingnews.org/server/routes/dynamic-page.js
@@ -1,8 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-global/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-global/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-global/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,

--- a/sites/aao.hns.org/server/routes/dynamic-page.js
+++ b/sites/aao.hns.org/server/routes/dynamic-page.js
@@ -1,8 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-global/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-global/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-global/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,

--- a/sites/ampulmonary.com/server/routes/dynamic-page.js
+++ b/sites/ampulmonary.com/server/routes/dynamic-page.js
@@ -1,12 +1,19 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-global-monorail/graphql/fragments/gallery-style-page');
 const contactUs = require('@ascend-media/package-global-monorail/templates/content/contact-us');
 const page = require('@ascend-media/package-global-monorail/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-global-monorail/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
   app.get('/page/:alias(contact-us)', withDynamicPage({
     template: contactUs,
     queryFragment,
+  }));
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
   }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,

--- a/sites/asa.org/server/routes/dynamic-page.js
+++ b/sites/asa.org/server/routes/dynamic-page.js
@@ -1,8 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-global/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-global/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-global/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,

--- a/sites/auadailynews.org/server/routes/dynamic-page.js
+++ b/sites/auadailynews.org/server/routes/dynamic-page.js
@@ -1,8 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-global/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-global/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-global/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,

--- a/sites/bulletin.entnet.org/server/routes/dynamic-page.js
+++ b/sites/bulletin.entnet.org/server/routes/dynamic-page.js
@@ -1,0 +1,17 @@
+const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
+const queryFragment = require('@ascend-media/package-daily/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-daily/graphql/fragments/gallery-style-page');
+const page = require('@ascend-media/package-daily/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-daily/templates/dynamic-page/gallery-style');
+
+module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
+  app.get('/page/:alias(*)', withDynamicPage({
+    template: page,
+    queryFragment,
+  }));
+};

--- a/sites/bulletin.entnet.org/server/routes/index.js
+++ b/sites/bulletin.entnet.org/server/routes/index.js
@@ -1,5 +1,6 @@
 const home = require('./home');
 const content = require('./content');
+const dynamicPages = require('./dynamic-page');
 const magazine = require('./magazine');
 const search = require('./search');
 const classifieds = require('./classifieds');
@@ -17,6 +18,9 @@ module.exports = (app) => {
 
   // Content Pages
   magazine(app);
+
+  // Dynamic Pages
+  dynamicPages(app);
 
   // Content Pages
   content(app);

--- a/sites/imex.ascendmedia.com/server/routes/dynamic-page.js
+++ b/sites/imex.ascendmedia.com/server/routes/dynamic-page.js
@@ -1,8 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-daily/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-daily/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-daily/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-daily/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,

--- a/sites/imexfrankfurt.ascendmedia.com/server/routes/dynamic-page.js
+++ b/sites/imexfrankfurt.ascendmedia.com/server/routes/dynamic-page.js
@@ -1,8 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-daily/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-daily/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-daily/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-daily/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,

--- a/sites/isc.hub.heart.org/server/routes/dynamic-page.js
+++ b/sites/isc.hub.heart.org/server/routes/dynamic-page.js
@@ -1,8 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-global/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-global/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-global/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,

--- a/sites/sessions.hub.heart.org/server/routes/dynamic-page.js
+++ b/sites/sessions.hub.heart.org/server/routes/dynamic-page.js
@@ -5,9 +5,10 @@ const page = require('@ascend-media/package-global/templates/dynamic-page');
 const galleryStyle = require('@ascend-media/package-global/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
-  app.get('/page/:alias(award-winners-test)', withDynamicPage({
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
     template: galleryStyle,
     queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
   }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,

--- a/sites/sessions.hub.heart.org/server/routes/dynamic-page.js
+++ b/sites/sessions.hub.heart.org/server/routes/dynamic-page.js
@@ -1,8 +1,14 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-global/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-global/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-global/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get('/page/:alias(award-winners-test)', withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,

--- a/sites/shm.org/server/routes/dynamic-page.js
+++ b/sites/shm.org/server/routes/dynamic-page.js
@@ -1,8 +1,15 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@ascend-media/package-global/graphql/fragments/dynamic-page');
+const galleryStyleQueryFragment = require('@ascend-media/package-global/graphql/fragments/gallery-style-page');
 const page = require('@ascend-media/package-global/templates/dynamic-page');
+const galleryStyle = require('@ascend-media/package-global/templates/dynamic-page/gallery-style');
 
 module.exports = (app) => {
+  app.get(/^\/page\/(awards.+)/, withDynamicPage({
+    template: galleryStyle,
+    queryFragment: galleryStyleQueryFragment,
+    aliasResolver: (req) => (req.params[0]),
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,


### PR DESCRIPTION
Global packages:
![Screenshot from 2023-08-18 08-49-36](https://github.com/parameter1/ascend-media-websites/assets/46794001/ec539303-1eda-4712-b883-d05a2ab5eac0)
![Screenshot from 2023-08-18 08-49-56](https://github.com/parameter1/ascend-media-websites/assets/46794001/2c930966-dda1-4460-bcd4-4bd751e4b874)
![Screenshot from 2023-08-18 08-50-22](https://github.com/parameter1/ascend-media-websites/assets/46794001/c7b00936-8bd5-4161-9ee9-df662291c2ea)

Showing on the other packages:

Daily:
![Screenshot from 2023-08-18 08-52-03](https://github.com/parameter1/ascend-media-websites/assets/46794001/35098ea6-520a-4840-9d2d-bd2fcc849e32)

Global-Monorail:
![Screenshot from 2023-08-18 08-52-39](https://github.com/parameter1/ascend-media-websites/assets/46794001/b87cbb00-5145-421a-a2ae-33afbf489409)

Technically Daily but wasn't sure if Bulletin was going to act weird or not:
![Screenshot from 2023-08-18 08-53-19](https://github.com/parameter1/ascend-media-websites/assets/46794001/1f2276a7-c55b-417f-a9d5-70499a799bc4)
