### PR TITLE
Use alternative logo for `aesthetics` section, AAD

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -46,7 +46,16 @@ $ const aboveContainer = get(input, "aboveContainer.renderBody");
     <marko-web-gtm-track-bus-event on="screen_change" />
     <marko-web-gtm-track-load-more />
     <marko-web-reveal-ad-listener select-all-targets=true />
-    <global-site-header />
+    $ console.log()
+    $ const isAestheticsSection = req.path.match(/^\/(aesthetics)$/);
+    $ const isAestheticsContentOrSubsection = req.path.match(/^\/(aesthetics)\//);
+    <if(get(config, "websiteContext.id") === "60c7666d46f24a64538b458d" && (isAestheticsSection || isAestheticsContentOrSubsection))>
+      $ const pathMatch = isAestheticsSection ? isAestheticsSection[1] : isAestheticsContentOrSubsection[1];
+      <global-site-header path-match=pathMatch />
+    </if>
+    <else>
+      <global-site-header />
+    </else>
     <default-theme-site-menu modifiers=["right"] />
     <if(site.config.noticePushdown)>
       <global-notice-pushdown-block />

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -46,7 +46,6 @@ $ const aboveContainer = get(input, "aboveContainer.renderBody");
     <marko-web-gtm-track-bus-event on="screen_change" />
     <marko-web-gtm-track-load-more />
     <marko-web-reveal-ad-listener select-all-targets=true />
-    $ console.log()
     $ const isAestheticsSection = req.path.match(/^\/(aesthetics)$/);
     $ const isAestheticsContentOrSubsection = req.path.match(/^\/(aesthetics)\//);
     <if(get(config, "websiteContext.id") === "60c7666d46f24a64538b458d" && (isAestheticsSection || isAestheticsContentOrSubsection))>

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -46,15 +46,7 @@ $ const aboveContainer = get(input, "aboveContainer.renderBody");
     <marko-web-gtm-track-bus-event on="screen_change" />
     <marko-web-gtm-track-load-more />
     <marko-web-reveal-ad-listener select-all-targets=true />
-    $ const isAestheticsSection = req.path.match(/^\/(aesthetics)$/);
-    $ const isAestheticsContentOrSubsection = req.path.match(/^\/(aesthetics)\//);
-    <if(get(config, "websiteContext.id") === "60c7666d46f24a64538b458d" && (isAestheticsSection || isAestheticsContentOrSubsection))>
-      $ const pathMatch = isAestheticsSection ? isAestheticsSection[1] : isAestheticsContentOrSubsection[1];
-      <global-site-header path-match=pathMatch />
-    </if>
-    <else>
-      <global-site-header />
-    </else>
+    <global-site-header />
     <default-theme-site-menu modifiers=["right"] />
     <if(site.config.noticePushdown)>
       <global-notice-pushdown-block />

--- a/packages/global/components/site-header.marko
+++ b/packages/global/components/site-header.marko
@@ -1,4 +1,6 @@
-$ const { config, site } = out.global;
+import { get } from "@parameter1/base-cms-object-path";
+
+$ const { config, site, req } = out.global;
 
 $ const blockName = input.blockName || "site-header";
 
@@ -21,12 +23,15 @@ $ if (navigation.secondary.length) tertiaryMods.push("no-left-margin");
 >
   <${input.aboveNav} />
   <default-theme-site-navbar modifiers=["secondary"]>
-    <if(input.pathMatch)>
-      <default-theme-site-navbar-brand title=site.get(`logos.${input.pathMatch}.title`) href=site.get(`logos.${input.pathMatch}.href`)>
+    $ const isAestheticsSection = req.path.match(/^\/(aesthetics)$/);
+    $ const isAestheticsContentOrSubsection = req.path.match(/^\/(aesthetics)\//);
+    <if(get(config, "websiteContext.id") === "60c7666d46f24a64538b458d" && (isAestheticsSection || isAestheticsContentOrSubsection))>
+      $ const pathMatch = isAestheticsSection ? isAestheticsSection[1] : isAestheticsContentOrSubsection[1];
+      <default-theme-site-navbar-brand title=site.get(`logos.${pathMatch}.title`) href=site.get(`logos.${pathMatch}.href`)>
         <default-theme-site-navbar-logo
-          alt=site.get(`logos.${input.pathMatch}.title`)
-          src=site.get(`logos.${input.pathMatch}.src`)
-          srcset=site.getAsArray(`logos.${input.pathMatch}.srcset`).join(",")
+          alt=site.get(`logos.${pathMatch}.title`)
+          src=site.get(`logos.${pathMatch}.src`)
+          srcset=site.getAsArray(`logos.${pathMatch}.srcset`).join(",")
         />
       </default-theme-site-navbar-brand>
     </if>

--- a/packages/global/components/site-header.marko
+++ b/packages/global/components/site-header.marko
@@ -21,13 +21,24 @@ $ if (navigation.secondary.length) tertiaryMods.push("no-left-margin");
 >
   <${input.aboveNav} />
   <default-theme-site-navbar modifiers=["secondary"]>
-    <default-theme-site-navbar-brand title=`${config.website("name")} Homepage` href=site.get("logos.navbar.href")>
-      <default-theme-site-navbar-logo
-        alt=config.website("name")
-        src=site.get("logos.navbar.src")
-        srcset=site.getAsArray("logos.navbar.srcset").join(",")
-      />
-    </default-theme-site-navbar-brand>
+    <if(input.pathMatch)>
+      <default-theme-site-navbar-brand title=site.get(`logos.${input.pathMatch}.title`) href=site.get(`logos.${input.pathMatch}.href`)>
+        <default-theme-site-navbar-logo
+          alt=site.get(`logos.${input.pathMatch}.title`)
+          src=site.get(`logos.${input.pathMatch}.src`)
+          srcset=site.getAsArray(`logos.${input.pathMatch}.srcset`).join(",")
+        />
+      </default-theme-site-navbar-brand>
+    </if>
+    <else>
+      <default-theme-site-navbar-brand title=`${config.website("name")} Homepage` href=site.get("logos.navbar.href")>
+        <default-theme-site-navbar-logo
+          alt=config.website("name")
+          src=site.get("logos.navbar.src")
+          srcset=site.getAsArray("logos.navbar.srcset").join(",")
+        />
+      </default-theme-site-navbar-brand>
+    </else>
     <default-theme-site-navbar-items
       items=navigation.secondary
       modifiers=["secondary"]

--- a/sites/aadmeetingnews.org/config/logos.js
+++ b/sites/aadmeetingnews.org/config/logos.js
@@ -13,4 +13,12 @@ module.exports = {
       'https://img.ascendmedia.com/files/base/ascend/hh/image/static/aad/AAD_Logo_Footer.png?h=200 2x',
     ],
   },
+  aesthetics: {
+    src: 'https://img.ascendmedia.com/files/base/ascend/hh/image/static/aad/AAD_Aesthetics_MNCheader_tagline.jpg?h=200',
+    srcset: [
+      'https://img.ascendmedia.com/files/base/ascend/hh/image/static/aad/AAD_Aesthetics_MNCheader_tagline.jpg?h=200 2x',
+    ],
+    href: '/aesthetics',
+    title: 'AAD Aesthetics News',
+  },
 };


### PR DESCRIPTION
Aesthetics section:
![Screenshot from 2023-09-06 10-37-56](https://github.com/parameter1/ascend-media-websites/assets/46794001/51515c8b-8a3b-4008-af79-8f0bfe52421c)

Content with primary section of Aesthetics:
![Screenshot from 2023-09-06 10-37-43](https://github.com/parameter1/ascend-media-websites/assets/46794001/dbcacf4d-6583-4344-a2d4-e431b6868af6)

Random section:
![Screenshot from 2023-09-06 10-38-04](https://github.com/parameter1/ascend-media-websites/assets/46794001/589b1a6a-c972-4481-a7cd-9b5e4d6e5295)

Content with primary section of **not** Aesthetics:
![Screenshot from 2023-09-06 10-38-09](https://github.com/parameter1/ascend-media-websites/assets/46794001/b99a3c59-3927-4665-8223-217ad124f660)
