### PR TITLE
Adjust globalMonorail newsletter middleware maxAge

### DIFF
--- a/packages/global-monorail/middleware/newsletter-state.js
+++ b/packages/global-monorail/middleware/newsletter-state.js
@@ -1,17 +1,18 @@
 const { get } = require('@parameter1/base-cms-object-path');
+const defaultValue = require('@parameter1/base-cms-marko-core/utils/default-value');
 
 const cookieName = 'enlPrompted';
 const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
+  const newsletterConfig = req.app.locals.site.getAsObject('newsletter');
+  const maxAgeInDays = defaultValue(get(newsletterConfig, 'pushdown.maxAgeInDays'), 14);
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const disabled = get(req, 'query.newsletterDisabled');
-  const canBeInitiallyExpanded = !(hasCookie || disabled);
-  const initiallyExpanded = (setCookie === true) && canBeInitiallyExpanded;
-
   // Expire in 14 days (2yr if already signed up)
-  const days = 365 * 2 || 14;
-  const maxAge = days * 24 * 60 * 60 * 1000;
+  const maxAge = maxAgeInDays * 24 * 60 * 60 * 1000;
+  const canBeInitiallyExpanded = !(hasCookie || disabled);
+  const initiallyExpanded = ((setCookie === true) && canBeInitiallyExpanded) || maxAge === 0;
 
-  if (initiallyExpanded) {
+  if (initiallyExpanded && maxAge !== 0) {
     res.cookie(cookieName, true, { maxAge });
   }
 

--- a/packages/global-monorail/start-server.js
+++ b/packages/global-monorail/start-server.js
@@ -4,10 +4,10 @@ const { set, get } = require('@parameter1/base-cms-object-path');
 const loadInquiry = require('@parameter1/base-cms-marko-web-inquiry');
 const htmlSitemapPagination = require('@parameter1/base-cms-marko-web-html-sitemap/middleware/paginated');
 const contactUsHandler = require('@parameter1/base-cms-marko-web-contact-us');
-const newsletterState = require('@parameter1/base-cms-marko-web-theme-monorail/middleware/newsletter-state');
 const identityX = require('@parameter1/base-cms-marko-web-identity-x');
 const idxRouteTemplates = require('./templates/user');
 
+const { newsletterState } = require('./middleware/newsletter-state');
 const document = require('./components/document');
 const components = require('./components');
 const fragments = require('./fragments');

--- a/sites/ampulmonary.com/config/newsletter.js
+++ b/sites/ampulmonary.com/config/newsletter.js
@@ -15,6 +15,7 @@ module.exports = {
     ...defaults,
   },
   pushdown: {
+    maxAgeInDays: 0,
     ...defaults,
     imagePath: 'files/base/ascend/hh/image/static/pulmonary/pulmonary-newsletter-half.png',
     description: 'amPulmonary enewsletter is the hub of news and cutting-edge information for pulmonary clinicians, researchers, and medical professionals interested in the latest developments.',


### PR DESCRIPTION
Allow for a site to set a maxAgeInDays with the newsletter.pushdown config to be able to set the max age on the push cookie